### PR TITLE
Allow a dot as the namespace root for an event

### DIFF
--- a/src/echo.js
+++ b/src/echo.js
@@ -14,7 +14,7 @@ class EchoEventFormatter {
      */
     static format(event)
     {
-        if (event.charAt(0) != '\\') {
+        if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
             event = defaultNamespace.value + '.' + event;
         } else {
             event = event.substr(1);


### PR DESCRIPTION
This would allow the use of a dot to indicate that the default namespace shouldn't be prepended, keeping event names more consistent.

`echo.channel('foo').listen('\\Bar')` would be the same as  `echo.channel('foo').listen('.Bar')`.