### PR TITLE
socket.io remove all listeners on unsubscribe

### DIFF
--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -119,6 +119,7 @@ export class SocketIoConnector extends Connector {
      * @return {void}
      */
     unsubscribe(channel: string): void {
+        this.socket.removeAllListeners();
         this.socket.emit('unsubscribe', {
             channel: channel,
             auth: this.options.auth || {}


### PR DESCRIPTION
HI, Taylor.
I'm using angular routes and "socket.io". When I'm going to the page with same channel second time, I'm receiving 2 sockets instead of 1. Unsubscribe working, but when I'm subscribing for same channel second time it duplicates callbacks. Calling method "removeAllListeners()" resolving this problem with "socket.io".