### PR TITLE
repair socket io leave method

### DIFF
--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -53,10 +53,16 @@ export class SocketIoChannel extends Channel {
      * @param  {Function} callback
      */
     on(event: string, callback: Function) {
-        this.subscription.on(event, (channel, data) => {
+        this.subscription.channel.on(event, (channel, data) => {
             if (this.name == channel) {
                 callback(data);
             }
         });
+
+        if(!this.subscription.events) this.subscription.events = {};
+
+        if(!_.has(this.subscription.events, event)) this.subscription.events[event] = [];
+
+        this.subscription.events[event].push(callback);
     }
 }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -1,4 +1,4 @@
-import { EventFormatter } from './../util';
+import { EventFormatter, ArrayHelper } from './../util';
 import { Channel } from './channel';
 
 /**
@@ -61,7 +61,7 @@ export class SocketIoChannel extends Channel {
 
         if(!this.subscription.events) this.subscription.events = {};
 
-        if(!_.has(this.subscription.events, event)) this.subscription.events[event] = [];
+        if(!ArrayHelper.has(this.subscription.events, event)) this.subscription.events[event] = [];
 
         this.subscription.events[event].push(callback);
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -53,7 +53,7 @@ export class SocketIoChannel extends Channel {
      * @param  {Function} callback
      */
     on(event: string, callback: Function) {
-        this.subscription.channel.on(event, (channel, data) => {
+        this.subscription.socket.on(event, (channel, data) => {
             if (this.name == channel) {
                 callback(data);
             }

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -13,7 +13,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     here(callback): SocketIoPresenceChannel {
         this.on('presence:subscribed', (members) => {
-            callback(members.map(m => m.user_info), this.subscription);
+            callback(members.map(m => m.user_info), this.subscription.socket);
         });
 
         return this;
@@ -27,7 +27,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     joining(callback): SocketIoPresenceChannel {
         this.on('presence:joining', (member) => {
-            callback(member.user_info, this.subscription);
+            callback(member.user_info, this.subscription.socket);
         });
 
         return this;
@@ -41,7 +41,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     leaving(callback): SocketIoPresenceChannel {
         this.on('presence:leaving', (member) => {
-            callback(member.user_info, this.subscription);
+            callback(member.user_info, this.subscription.socket);
         });
 
         return this;

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -89,7 +89,7 @@ export class SocketIoConnector extends Connector {
     createChannel(channel: string): any {
         if (!this.channels[channel]) {
             this.channels[channel] = {
-                channel: this.subscribe(channel)
+                socket: this.subscribe(channel)
             };
         }
 
@@ -152,7 +152,7 @@ export class SocketIoConnector extends Connector {
     }
 
     private clearCallbacks(channelName: string) {
-        let channel = this.channels[channelName]['channel'];
+        let channel = this.channels[channelName]['socket'];
         let events = this.channels[channelName]['events'];
 
         for (let event in events) {

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -88,9 +88,9 @@ export class SocketIoConnector extends Connector {
      */
     createChannel(channel: string): any {
         if (!this.channels[channel]) {
-            this.channels[channel] = _.create({
+            this.channels[channel] = {
                 channel: this.subscribe(channel)
-            });
+            };
         }
 
         return this.channels[channel];
@@ -155,11 +155,10 @@ export class SocketIoConnector extends Connector {
         let channel = this.channels[channelName]['channel'];
         let events = this.channels[channelName]['events'];
 
-        _.map(_.keys(events), event => {
-
-            _.map(events[event], callback => {
+        for (let event in events) {
+            events[event].forEach(callback => {
                 channel.removeListener(event, callback)
             });
-        });
+        }
     }
 }

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -88,7 +88,9 @@ export class SocketIoConnector extends Connector {
      */
     createChannel(channel: string): any {
         if (!this.channels[channel]) {
-            this.channels[channel] = this.subscribe(channel);
+            this.channels[channel] = _.create({
+                channel: this.subscribe(channel)
+            });
         }
 
         return this.channels[channel];
@@ -104,6 +106,8 @@ export class SocketIoConnector extends Connector {
 
         channels.forEach((channelName: string, index: number) => {
             if (this.channels[channelName]) {
+                this.clearCallbacks(channelName);
+
                 this.unsubscribe(channelName);
 
                 delete this.channels[channelName];
@@ -131,7 +135,6 @@ export class SocketIoConnector extends Connector {
      * @return {void}
      */
     unsubscribe(channel: string): void {
-        this.socket.removeAllListeners();
 
         this.socket.emit('unsubscribe', {
             channel: channel,
@@ -146,5 +149,17 @@ export class SocketIoConnector extends Connector {
      */
     socketId(): string {
         return this.socket.id;
+    }
+
+    private clearCallbacks(channelName: string) {
+        let channel = this.channels[channelName]['channel'];
+        let events = this.channels[channelName]['events'];
+
+        _.map(_.keys(events), event => {
+
+            _.map(events[event], callback => {
+                channel.removeListener(event, callback)
+            });
+        });
     }
 }

--- a/src/util/array-helper.ts
+++ b/src/util/array-helper.ts
@@ -1,5 +1,5 @@
 /**
- * Event helper
+ * Array helper
  */
 export class ArrayHelper {
 

--- a/src/util/array-helper.ts
+++ b/src/util/array-helper.ts
@@ -1,0 +1,9 @@
+/**
+ * Event helper
+ */
+export class ArrayHelper {
+
+    static has(obj, key) {
+        return obj != null && Object.prototype.hasOwnProperty.call(obj, key);
+    }
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,2 @@
 export * from './event-formatter'
+export * from './array-helper'

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,4 +3,3 @@
 declare let Pusher: any;
 declare let io: any;
 declare let Vue: any;
-declare let _: any;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,3 +3,4 @@
 declare let Pusher: any;
 declare let io: any;
 declare let Vue: any;
+declare let _: any;


### PR DESCRIPTION
Hi, Taylor

3 days ago I sent to you PR with unsubscribe socket.io method override.
Method "this.socket.removeAllListeners();" doesn't work like I expected. This method deletes all callbacks from all channels. For example I have a reconnector and channel that listening new orders. When I'll leave from orders channel, this method will also remove a reconnector callbacks.

I wrote a method, that saves a collection of channel callbacks. And when user will try to unsubscrube from a channel, then all callbacks will be also deleted.

Now channel collection looks like: 

`this.channels = {`
`    'channel-name' => [`
`        'channel' => channel_object,`
`        'events' => {`
`             "event-name" => [  functions.... ]`
`        }`
`    ]`
`}`

My PR for now working perfect with "underscore". Of course you can do refactoring and remove underscore. These methods tested and work as expected. Right now, method "leave" works good with 'socket.io'. When user is trying to leave from a channel it unsubscribes and removes all callbacks only from one channel, by using method from "socket.io" library - removeListener( event, callback).

P.S. Sorry for my bad english 