### PR TITLE
Allow pass custom socketIo options

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -16,7 +16,8 @@ export abstract class Connector {
         csrfToken: null,
         host: null,
         key: null,
-        namespace: null
+        namespace: null,
+	socketIoOptions: {}
     };
 
     /**

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -26,7 +26,7 @@ export class SocketIoConnector extends Connector {
      * @return void
      */
     connect(): void {
-        this.socket = io(this.options.host);
+        this.socket = io(this.options.host, this.options.socketIoOptions);
 
         return this.socket;
     }


### PR DESCRIPTION
Hi,

With this options we are allowed to to use same url - without custom port  to connect on socket.io servers.

Example:

We have a laravel-echo-server ( https://github.com/tlaverdure/laravel-echo-server ) running on  port 3001 listening on localhost.

We have a apache virtual host like this:
http://pastebin.com/SMeD6yaZ

This allow us to forward /socket/socket.io direct to laravel-echo-server
with options to upgrade to websocket too.

On our echo-bootstrap we have:

`
window.Echo = new Echo({

    broadcaster: 'socket.io',

    host: 'http://www.myapp.com/',

    socketIoOptions: { path: '/socket/socket.io' }

});
`



What is the main goal:
Our entire app are running on a single addres, and single port.


