### PR TITLE
Fix for Socket.io Channel Broadcasting

### DIFF
--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -5,14 +5,6 @@ import { Channel } from './channel';
  * This class represents a Socket.io channel.
  */
 export class SocketIoChannel extends Channel {
-
-    /**
-     * Channel object.
-     *
-     * @type {object}
-     */
-    channel: any;
-
     /**
      * The event formatter.
      *
@@ -23,14 +15,17 @@ export class SocketIoChannel extends Channel {
     /**
      * Create a new class instance.
      *
-     * @param  {object}  channel
-     * @param  {any}  options
+     * @param  {string} name
+     * @param  {object} subscription
+     * @param  {any} options
      */
-    constructor(channel: any, options: any) {
+    constructor(
+        public name: string,
+        public subscription: any,
+        public options: any
+    ) {
         super();
 
-        this.channel = channel;
-        this.options = options;
         this.eventFormatter = new EventFormatter;
 
         if (this.options.namespace) {
@@ -58,6 +53,10 @@ export class SocketIoChannel extends Channel {
      * @param  {Function} callback
      */
     on(event: string, callback: Function) {
-        this.channel.on(event, callback);
+        this.subscription.on(event, (channel, data) => {
+            if (this.name == channel) {
+                callback(data);
+            }
+        });
     }
 }

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -13,7 +13,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     here(callback): SocketIoPresenceChannel {
         this.on('presence:subscribed', (members) => {
-            callback(members.map(m => m.user_info), this.channel);
+            callback(members.map(m => m.user_info), this.subscription);
         });
 
         return this;
@@ -27,7 +27,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     joining(callback): SocketIoPresenceChannel {
         this.on('presence:joining', (member) => {
-            callback(member.user_info, this.channel);
+            callback(member.user_info, this.subscription);
         });
 
         return this;
@@ -41,7 +41,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     leaving(callback): SocketIoPresenceChannel {
         this.on('presence:leaving', (member) => {
-            callback(member.user_info, this.channel);
+            callback(member.user_info, this.subscription);
         });
 
         return this;

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -45,7 +45,11 @@ export class SocketIoConnector extends Connector {
      * @return {SocketIoChannel}
      */
     channel(channel: string): SocketIoChannel {
-        return new SocketIoChannel(this.createChannel(channel), this.options);
+        return new SocketIoChannel(
+            channel,
+            this.createChannel(channel),
+            this.options
+        );
     }
 
     /**
@@ -55,7 +59,11 @@ export class SocketIoConnector extends Connector {
      * @return {SocketIoChannel}
      */
     privateChannel(channel: string): SocketIoChannel {
-        return new SocketIoChannel(this.createChannel('private-' + channel), this.options);
+        return new SocketIoChannel(
+            channel,
+            this.createChannel('private-' + channel),
+            this.options
+        );
     }
 
     /**
@@ -65,7 +73,11 @@ export class SocketIoConnector extends Connector {
      * @return {PresenceChannel}
      */
     presenceChannel(channel: string): SocketIoPresenceChannel {
-        return new SocketIoPresenceChannel(this.createChannel('presence-' + channel), this.options);
+        return new SocketIoPresenceChannel(
+            channel,
+            this.createChannel('presence-' + channel),
+            this.options
+        );
     }
 
     /**


### PR DESCRIPTION
Fixed the socket.io connector to listen to channel events that are broadcasted to a specific room, not all sockets that are part of a room. The way socket.io works, a single socket subscribes to one thread and the server allows that socket to join multiple "rooms", which we call channels. When you want to broadcast to a specific channel you have to emit to all sockets connected to a room. 

This PR ensures that channels are provided a name when created so that it's name can be matched to a channel name returned from the server. This shouldn't change anything regarding the public API of Echo.

This will be available once Laravel Echo Server 1.0 is released shortly.

Fixes https://github.com/laravel/echo/issues/39