### PR TITLE
Socket.io Leave Method Improvements and Channel/Connector Updates

### DIFF
--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -2,7 +2,6 @@
  * This class represents a basic channel.
  */
 export abstract class Channel {
-
     /**
      * The Echo options.
      *

--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -14,7 +14,7 @@ export abstract class Channel {
      * Listen for an event on the channel instance.
      *
      * @param  {string} event
-     * @param  {Function}   callback
+     * @param  {Function} callback
      * @return {Channel}
      */
     abstract listen(event: string, callback: Function): Channel;
@@ -23,7 +23,7 @@ export abstract class Channel {
      * Listen for an event on the channel instance.
      *
      * @param  {string} event
-     * @param  {Function}   callback
+     * @param  {Function} callback
      * @return {Channel}
      */
     notification(callback: Function): Channel {

--- a/src/channel/presence-channel.ts
+++ b/src/channel/presence-channel.ts
@@ -6,9 +6,9 @@ export interface PresenceChannel {
      * Register a callback to be called anytime the member list changes.
      *
      * @param  {Function} callback
-     * @return {object} this
+     * @return {object} PresenceChannel
      */
-    here(callback): PresenceChannel;
+    here(callback: Function): PresenceChannel;
 
     /**
      * Listen for someone joining the channel.
@@ -16,13 +16,13 @@ export interface PresenceChannel {
      * @param  {Function} callback
      * @return {PresenceChannel}
      */
-    joining(callback): PresenceChannel;
+    joining(callback: Function): PresenceChannel;
 
     /**
      * Listen for someone leaving the channel.
      *
-     * @param  {Function}  callback
+     * @param  {Function} callback
      * @return {PresenceChannel}
      */
-    leaving(callback): PresenceChannel;
+    leaving(callback: Function): PresenceChannel;
 }

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -5,13 +5,26 @@ import { Channel } from './channel';
  * This class represents a Pusher channel.
  */
 export class PusherChannel extends Channel {
-
     /**
-     * Channel object.
+     * The name of the channel.
      *
      * @type {object}
      */
-    channel: any;
+    name: any;
+
+    /**
+     * The pusher client instance.
+     *
+     * @type {any}
+     */
+    pusher: any;
+
+    /**
+     * Channel options.
+     *
+     * @type {any}
+     */
+    options: any;
 
     /**
      * The event formatter.
@@ -34,12 +47,12 @@ export class PusherChannel extends Channel {
      * @param  {any} pusher
      * @param  {any}  options
      */
-    constructor(
-        public name: any,
-        public pusher: any,
-        public options: any
-    ) {
+    constructor(name: any, pusher: any, options: any) {
         super();
+
+        this.name = name;
+        this.pusher = pusher;
+        this.options = options;
 
         this.eventFormatter = new EventFormatter;
 

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -21,21 +21,51 @@ export class PusherChannel extends Channel {
     eventFormatter: EventFormatter;
 
     /**
+     * The subsciption of the channel.
+     *
+     * @type {any}
+     */
+    subscription: any;
+
+    /**
      * Create a new class instance.
      *
-     * @param  {object}  channel
+     * @param  {object} name
+     * @param  {any} pusher
      * @param  {any}  options
      */
-    constructor(channel: any, options: any) {
+    constructor(
+        public name: any,
+        public pusher: any,
+        public options: any) {
         super();
 
-        this.channel = channel;
-        this.options = options;
         this.eventFormatter = new EventFormatter;
 
         if (this.options.namespace) {
             this.eventFormatter.namespace(this.options.namespace);
         }
+
+        this.subscribe();
+    }
+
+    /**
+     * Subscribe to a Pusher channel.
+     *
+     * @param  {string} channel
+     * @return {object}
+     */
+    subscribe(): any {
+        this.subscription = this.pusher.subscribe(this.name);
+    }
+
+    /**
+     * Unsubscribe from a Pusher channel.
+     *
+     * @return {void}
+     */
+    unsubscribe(channel: string): void {
+        this.pusher.unsubscribe(this.name);
     }
 
     /**
@@ -46,7 +76,7 @@ export class PusherChannel extends Channel {
      * @return {PusherChannel}
      */
     listen(event: string, callback: Function): PusherChannel {
-        this.bind(this.eventFormatter.format(event), callback);
+        this.on(this.eventFormatter.format(event), callback);
 
         return this;
     }
@@ -57,7 +87,7 @@ export class PusherChannel extends Channel {
      * @param  {string}   event
      * @param  {Function} callback
      */
-    bind(event: string, callback: Function) {
-        this.channel.bind(event, callback);
+    on(event: string, callback: Function) {
+        this.subscription.bind(event, callback);
     }
 }

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -37,7 +37,8 @@ export class PusherChannel extends Channel {
     constructor(
         public name: any,
         public pusher: any,
-        public options: any) {
+        public options: any
+    ) {
         super();
 
         this.eventFormatter = new EventFormatter;
@@ -86,8 +87,9 @@ export class PusherChannel extends Channel {
      *
      * @param  {string}   event
      * @param  {Function} callback
+     * @return {void}
      */
-    on(event: string, callback: Function) {
+    on(event: string, callback: Function): void {
         this.subscription.bind(event, callback);
     }
 }

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -65,7 +65,7 @@ export class PusherChannel extends Channel {
      *
      * @return {void}
      */
-    unsubscribe(channel: string): void {
+    unsubscribe(): void {
         this.pusher.unsubscribe(this.name);
     }
 

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -5,7 +5,6 @@ import { PresenceChannel } from './presence-channel';
  * This class represents a Pusher presence channel.
  */
 export class PusherPresenceChannel extends PusherChannel implements PresenceChannel {
-
     /**
      * Register a callback to be called anytime the member list changes.
      *

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -13,7 +13,7 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      */
     here(callback): PusherPresenceChannel {
         this.on('pusher:subscription_succeeded', (data) => {
-            callback(Object.keys(data.members).map(k => data.members[k]), this.name);
+            callback(Object.keys(data.members).map(k => data.members[k]));
         });
 
         return this;
@@ -27,7 +27,7 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      */
     joining(callback): PusherPresenceChannel {
         this.on('pusher:member_added', (member) => {
-            callback(member.info, this.name);
+            callback(member.info);
         });
 
         return this;
@@ -41,7 +41,7 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      */
     leaving(callback): PusherPresenceChannel {
         this.on('pusher:member_removed', (member) => {
-            callback(member.info, this.name);
+            callback(member.info);
         });
 
         return this;

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -13,8 +13,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @return {object} this
      */
     here(callback): PusherPresenceChannel {
-        this.bind('pusher:subscription_succeeded', (data) => {
-            callback(Object.keys(data.members).map(k => data.members[k]), this.channel);
+        this.on('pusher:subscription_succeeded', (data) => {
+            callback(Object.keys(data.members).map(k => data.members[k]), this.name);
         });
 
         return this;
@@ -27,8 +27,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @return {PusherPresenceChannel}
      */
     joining(callback): PusherPresenceChannel {
-        this.bind('pusher:member_added', (member) => {
-            callback(member.info, this.channel);
+        this.on('pusher:member_added', (member) => {
+            callback(member.info, this.name);
         });
 
         return this;
@@ -41,8 +41,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @return {PusherPresenceChannel}
      */
     leaving(callback): PusherPresenceChannel {
-        this.bind('pusher:member_removed', (member) => {
-            callback(member.info, this.channel);
+        this.on('pusher:member_removed', (member) => {
+            callback(member.info, this.name);
         });
 
         return this;

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -6,6 +6,27 @@ import { Channel } from './channel';
  */
 export class SocketIoChannel extends Channel {
     /**
+     * The name of the channel.
+     *
+     * @type {object}
+     */
+    name: any;
+
+    /**
+     * The socket.io client instance.
+     *
+     * @type {any}
+     */
+    socket: any;
+
+    /**
+     * Channel options.
+     *
+     * @type {any}
+     */
+    options: any;
+
+    /**
      * The event formatter.
      *
      * @type {EventFormatter}
@@ -33,12 +54,12 @@ export class SocketIoChannel extends Channel {
      * @param  {any} socket
      * @param  {any} options
      */
-    constructor(
-        public name: string,
-        public socket: any,
-        public options: any
-    ) {
+    constructor(name: string, socket: any, options: any) {
         super();
+
+        this.name = name;
+        this.socket = socket;
+        this.options = options;
 
         this.eventFormatter = new EventFormatter;
 

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -91,7 +91,7 @@ export class SocketIoChannel extends Channel {
     /**
      * Bind the channel's socket to an event and store the callback.
      *
-     * @param  {string}   event
+     * @param  {string} event
      * @param  {Function} callback
      */
     on(event: string, callback: Function): void {
@@ -110,6 +110,7 @@ export class SocketIoChannel extends Channel {
      *
      * @param  {string}   event
      * @param  {Function} callback
+     * @return {void}
      */
     bind(event: string, callback: Function): void {
         this.events[event] = this.events[event] || [];

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -12,7 +12,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      */
     here(callback: Function): SocketIoPresenceChannel {
         this.on('presence:subscribed', (members) => {
-            callback(members.map(m => m.user_info), this.subscription);
+            callback(members.map(m => m.user_info));
         });
 
         return this;
@@ -25,9 +25,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      * @return {SocketIoPresenceChannel}
      */
     joining(callback: Function): SocketIoPresenceChannel {
-        this.on('presence:joining', (member) => {
-            callback(member.user_info, this.subscription);
-        });
+        this.on('presence:joining', (member) => callback(member.user_info));
 
         return this;
     }
@@ -39,9 +37,7 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      * @return {SocketIoPresenceChannel}
      */
     leaving(callback: Function): SocketIoPresenceChannel {
-        this.on('presence:leaving', (member) => {
-            callback(member.user_info, this.subscription);
-        });
+        this.on('presence:leaving', (member) => callback(member.user_info));
 
         return this;
     }

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -4,14 +4,13 @@ import { PresenceChannel, SocketIoChannel } from './';
  * This class represents a Socket.io presence channel.
  */
 export class SocketIoPresenceChannel extends SocketIoChannel implements PresenceChannel {
-
     /**
      * Register a callback to be called anytime the member list changes.
      *
      * @param  {Function} callback
-     * @return {object} this
+     * @return {object} SocketIoPresenceChannel
      */
-    here(callback): SocketIoPresenceChannel {
+    here(callback: Function): SocketIoPresenceChannel {
         this.on('presence:subscribed', (members) => {
             callback(members.map(m => m.user_info), this.subscription);
         });
@@ -23,9 +22,9 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      * Listen for someone joining the channel.
      *
      * @param  {Function} callback
-     * @return {PusherPresenceChannel}
+     * @return {SocketIoPresenceChannel}
      */
-    joining(callback): SocketIoPresenceChannel {
+    joining(callback: Function): SocketIoPresenceChannel {
         this.on('presence:joining', (member) => {
             callback(member.user_info, this.subscription);
         });
@@ -37,9 +36,9 @@ export class SocketIoPresenceChannel extends SocketIoChannel implements Presence
      * Listen for someone leaving the channel.
      *
      * @param  {Function}  callback
-     * @return {PusherPresenceChannel}
+     * @return {SocketIoPresenceChannel}
      */
-    leaving(callback): SocketIoPresenceChannel {
+    leaving(callback: Function): SocketIoPresenceChannel {
         this.on('presence:leaving', (member) => {
             callback(member.user_info, this.subscription);
         });

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -28,8 +28,10 @@ export abstract class Connector {
 
     /**
      * Create a new class instance.
+     *
+     * @params  {any} options
      */
-    constructor(options) {
+    constructor(options: any) {
         this.setOptions(options);
 
         this.connect();
@@ -39,9 +41,9 @@ export abstract class Connector {
      * Merge the custom options with the defaults.
      *
      * @param  {any}  options
-     * @return {object}
+     * @return {any}
      */
-    protected setOptions(options: any) {
+    protected setOptions(options: any): any {
         this.options = Object.assign(this._defaultOptions, options);
 
         if (this.csrfToken()) {
@@ -53,8 +55,10 @@ export abstract class Connector {
 
     /**
      * Extract the CSRF token from the page.
+     *
+     * @return {string}
      */
-    protected csrfToken() {
+    protected csrfToken(): string {
         let selector = document.querySelector('meta[name="csrf-token"]');
 
         if (window['Laravel'] && window['Laravel'].csrfToken) {
@@ -86,8 +90,8 @@ export abstract class Connector {
     /**
      * Get a private channel instance by name.
      *
-     * @param  {string}  channel
-     * @return {PusherChannel}
+     * @param  {string} channel
+     * @return {Channel}
      */
     abstract privateChannel(channel: string): Channel;
 
@@ -103,8 +107,9 @@ export abstract class Connector {
      * Leave the given channel.
      *
      * @param  {string} channel
+     * @return {void}
      */
-    abstract leave(channel: string);
+    abstract leave(channel: string): void;
 
     /**
      * Get the socket_id of the connection.

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -7,7 +7,6 @@ import {
  * This class creates a connector to Pusher.
  */
 export class PusherConnector extends Connector {
-
     /**
      * The Pusher instance.
      *

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -20,7 +20,7 @@ export class PusherConnector extends Connector {
      *
      * @type {array}
      */
-    channels: any[] = [];
+    channels: any = {};
 
     /**
      * Create a fresh Pusher connection.
@@ -33,53 +33,68 @@ export class PusherConnector extends Connector {
 
     /**
      * Listen for an event on a channel instance.
+     *
+     * @param  {string} name
+     * @param  {event} string
+     * @param  {Function} callback
+     * @return {PusherChannel}
      */
-    listen(channel: string, event: string, callback: Function) {
-        return this.channel(channel).listen(event, callback);
+    listen(name: string, event: string, callback: Function): PusherChannel {
+        return this.channel(name).listen(event, callback);
     }
 
     /**
      * Get a channel instance by name.
      *
-     * @param  {string}  channel
+     * @param  {string} name
      * @return {PusherChannel}
      */
-    channel(channel: string): PusherChannel {
-        return new PusherChannel(this.createChannel(channel), this.options);
+    channel(name: string): PusherChannel {
+        if (!this.channels[name]) {
+            this.channels[name] = new PusherChannel(
+                name,
+                this.pusher,
+                this.options
+            );
+        }
+
+        return this.channels[name];
     }
 
     /**
      * Get a private channel instance by name.
      *
-     * @param  {string}  channel
+     * @param  {string} name
      * @return {PusherChannel}
      */
-    privateChannel(channel: string): PusherChannel {
-        return new PusherChannel(this.createChannel('private-' + channel), this.options);
+    privateChannel(name: string): PusherChannel {
+        if (!this.channels['private-' + name]) {
+            this.channels['private-' + name] = new PusherChannel(
+                'private-' + name,
+                this.pusher,
+                this.options
+            );
+        }
+
+        return this.channels['private-' + name];
     }
 
     /**
      * Get a presence channel instance by name.
      *
-     * @param  {string} channel
+     * @param  {string} name
      * @return {PresenceChannel}
      */
-    presenceChannel(channel: string): PresenceChannel {
-        return new PusherPresenceChannel(this.createChannel('presence-' + channel), this.options);
-    }
-
-    /**
-     * Create and subscribe to a fresh channel instance.
-     *
-     * @param  {string} channel
-     * @return {object}
-     */
-    createChannel(channel: string): any {
-        if (!this.channels[channel]) {
-            this.channels[channel] = this.subscribe(channel);
+    presenceChannel(name: string): PresenceChannel {
+        if (!this.channels['presence-' + name]) {
+            this.channels['presence-' + name] = new PusherPresenceChannel(
+                'presence-' + name,
+                this.pusher,
+                this.options
+            );
         }
 
-        return this.channels[channel];
+        return this.channels['presence-' + name];
     }
 
     /**
@@ -87,36 +102,16 @@ export class PusherConnector extends Connector {
      *
      * @param  {string} channel
      */
-    leave(channel: string) {
-        let channels = [channel, 'private-' + channel, 'presence-' + channel];
+    leave(name: string) {
+        let channels = [name, 'private-' + name, 'presence-' + name];
 
-        channels.forEach((channelName: string, index: number) => {
-            if (this.channels[channelName]) {
-                this.unsubscribe(channelName);
+        channels.forEach((name: string, index: number) => {
+            if (this.channels[name]) {
+                this.channels[name].unsubscribe();
 
-                delete this.channels[channelName];
+                delete this.channels[name];
             }
         });
-    }
-
-    /**
-     * Subscribe to a Pusher channel.
-     *
-     * @param  {string} channel
-     * @return {object}
-     */
-    subscribe(channel: string): any {
-        return this.pusher.subscribe(channel);
-    }
-
-    /**
-     * Unsubscribe from a Pusher channel.
-     *
-     * @param  {string} channel
-     * @return {void}
-     */
-    unsubscribe(channel: string): void {
-        this.pusher.unsubscribe(channel);
     }
 
     /**

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -5,7 +5,6 @@ import { SocketIoChannel, SocketIoPresenceChannel } from './../channel';
  * This class creates a connnector to a Socket.io server.
  */
 export class SocketIoConnector extends Connector {
-
     /**
      * The Socket.io connection instance.
      *
@@ -33,6 +32,11 @@ export class SocketIoConnector extends Connector {
 
     /**
      * Listen for an event on a channel instance.
+     *
+     * @param  {string} name
+     * @param  {string} event
+     * @param  {Function} callback
+     * @return {SocketIoChannel}
      */
     listen(name: string, event: string, callback: Function): SocketIoChannel {
         return this.channel(name).listen(event, callback);
@@ -41,7 +45,7 @@ export class SocketIoConnector extends Connector {
     /**
      * Get a channel instance by name.
      *
-     * @param  {string}  name
+     * @param  {string} name
      * @return {SocketIoChannel}
      */
     channel(name: string): SocketIoChannel {
@@ -59,7 +63,7 @@ export class SocketIoConnector extends Connector {
     /**
      * Get a private channel instance by name.
      *
-     * @param  {string}  name
+     * @param  {string} name
      * @return {SocketIoChannel}
      */
     privateChannel(name: string): SocketIoChannel {
@@ -78,7 +82,7 @@ export class SocketIoConnector extends Connector {
      * Get a presence channel instance by name.
      *
      * @param  {string} name
-     * @return {PresenceChannel}
+     * @return {SocketIoPresenceChannel}
      */
     presenceChannel(name: string): SocketIoPresenceChannel {
         if (!this.channels['presence-' + name]) {


### PR DESCRIPTION
@pderiy pointed out some issues with event callbacks not being properly cleared with socket.io. I've revised his code to be a bit more concise. The pusher client appears to take care of this so no additional code is needed there. 

I also updated channels to move their subscribe/unsubscribe logic within themselves so that channels have full control of when they subscribe, unsubscribe, and in socket.io's case, handle the tracking the state of event listeners. 

**The connectors are now only responsible for:**

- Creating a connection with the socket provider.
- Creating the different types of channels.
- Facilitating the leaving of channels.

**Channels are responsible for:**

- Subscribing and any logic required to create a channel instance. 
- Unsubscribing along with any logic that goes along with tearing down a channel.

Also some code cleanup.

Fixes https://github.com/laravel/echo/pull/33.


_No breaking changes to the public API._
