### PR TITLE
Updated the way X-Socket-ID header is set

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -50,7 +50,7 @@ class Echo {
     registerVueRequestInterceptor() {
         Vue.http.interceptors.push((request, next) => {
             if (this.socketId()) {
-                request.headers.set('X-Socket-ID', _this.socketId());
+                request.headers.set('X-Socket-ID', this.socketId());
             }
 
             next();

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -50,7 +50,7 @@ class Echo {
     registerVueRequestInterceptor() {
         Vue.http.interceptors.push((request, next) => {
             if (this.socketId()) {
-                request.headers['X-Socket-ID'] = this.socketId();
+                request.headers.set('X-Socket-ID', _this.socketId());
             }
 
             next();


### PR DESCRIPTION
This fixes the `X-Socket-ID` header not being set correctly and therefore rendering `->toOthers()` (`dontBroadcastToCurrentUser()`) useless.