### PR TITLE
Added global settings (currently primarily for the event-formatter);

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -47,14 +47,14 @@ export class PusherChannel extends Channel {
      * @param  {object} name
      * @param  {any}  options
      */
-    constructor(pusher: any, name: any, options: any) {
+    constructor(pusher: any, name: any, options: any, settings: any) {
         super();
 
         this.name = name;
         this.pusher = pusher;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter;
+        this.eventFormatter = new EventFormatter(settings);
 
         if (this.options.namespace) {
             this.eventFormatter.namespace(this.options.namespace);

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -54,14 +54,14 @@ export class SocketIoChannel extends Channel {
      * @param  {string} name
      * @param  {any} options
      */
-    constructor(socket: any, name: string, options: any) {
+    constructor(socket: any, name: string, options: any, settings: any) {
         super();
 
         this.name = name;
         this.socket = socket;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter;
+        this.eventFormatter = new EventFormatter(settings);
 
         if (this.options.namespace) {
             this.eventFormatter.namespace(this.options.namespace);

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -27,12 +27,21 @@ export abstract class Connector {
     options: any;
 
     /**
+     * Global options
+     *
+     * @type: {object}
+     */
+    settings: any;
+
+    /**
      * Create a new class instance.
      *
      * @params  {any} options
      */
-    constructor(options: any) {
+    constructor(options: any, settings: any) {
         this.setOptions(options);
+
+        this.settings = settings;
 
         this.connect();
     }

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -53,7 +53,8 @@ export class PusherConnector extends Connector {
             this.channels[name] = new PusherChannel(
                 this.pusher,
                 name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 
@@ -71,7 +72,8 @@ export class PusherConnector extends Connector {
             this.channels['private-' + name] = new PusherChannel(
                 this.pusher,
                 'private-' + name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 
@@ -89,7 +91,8 @@ export class PusherConnector extends Connector {
             this.channels['presence-' + name] = new PusherPresenceChannel(
                 this.pusher,
                 'presence-' + name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -53,7 +53,8 @@ export class SocketIoConnector extends Connector {
             this.channels[name] = new SocketIoChannel(
                 this.socket,
                 name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 
@@ -71,7 +72,8 @@ export class SocketIoConnector extends Connector {
             this.channels['private-' + name] = new SocketIoChannel(
                 this.socket,
                 'private-' + name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 
@@ -89,7 +91,8 @@ export class SocketIoConnector extends Connector {
             this.channels['presence-' + name] = new SocketIoPresenceChannel(
                 this.socket,
                 'presence-' + name,
-                this.options
+                this.options,
+                this.settings
             );
         }
 

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -4,11 +4,15 @@
 export class EventFormatter {
 
     /**
-     * Default event namespace.
+     * Global options
      *
-     * @type {string}
+     * @type: {object}
      */
-    defaultNamespace: string = 'App.Events';
+    settings: any;
+
+    constructor(settings: any) {
+        this.settings = settings;
+    }
 
     /**
      * Format the given event name.
@@ -17,13 +21,19 @@ export class EventFormatter {
      * @return {string}
      */
     format(event: string): string {
-        if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
-            event = this.defaultNamespace + '.' + event;
-        } else {
+        // If we're prefixing the event with namespaces and the first char isn't '\' or '.'
+        if (this.settings.prefixNamespace && event.charAt(0) != '\\' && event.charAt(0) != '.')
+        {
+            event = this.settings.defaultNamespace + '.' + event;
+        }
+        // If we're prefixing and one of those chars start off the string
+        else if(this.settings.prefixNamespace)
+        {
             event = event.substr(1);
         }
 
-        return event.replace(/\./g, '\\');
+        // If we're converting namespaces, replace '.' with '\'
+        return (this.settings.convertNameSpaces) ? event.replace(/\./g, '\\') : event;
     }
 
     /**


### PR DESCRIPTION
 - defaultNameSpace: 'App.Events' - makes it trivial to set a default if a developer uses a different app namespace
 - prefixNamespace: bool(true) - if an app uses custom broadcastAs, no namespace prefixes are required (including having to start the event name with a dot).
 - convertNameSpaces: bool(true) - should dots in the event name be converted to \


All the properties can optionally be defined, with defaults that are set to the current way things work.

Example:

```js
window.Echo = new Echo({
    broadcaster: 'pusher',
    key: 'your-pusher-key'
}, {
    defaultNameSpace: 'Project.Events'
});
```