### PR TITLE
Allows namespace option to be set to false.

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -102,9 +102,9 @@ export class PusherChannel extends Channel {
      * @param  {Function} callback
      * @return {void}
      */
-    on(event: string, callback: Function): void {
+    on(event: string, callback: Function): PusherChannel {
         this.subscription.bind(event, callback);
-        
+
         return this;
     }
 }

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -16,7 +16,7 @@ export abstract class Connector {
         csrfToken: null,
         host: null,
         key: null,
-        namespace: null
+        namespace: ''
     };
 
     /**

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -8,7 +8,7 @@ export class EventFormatter {
      *
      * @type {string}
      */
-    defaultNamespace: string = 'App.Events';
+    defaultNamespace: string | boolean = 'App.Events';
 
     /**
      * Format the given event name.
@@ -17,10 +17,12 @@ export class EventFormatter {
      * @return {string}
      */
     format(event: string): string {
-        if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
-            event = this.defaultNamespace + '.' + event;
-        } else {
-            event = event.substr(1);
+        if (this.defaultNamespace !== false) {
+            if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
+                event = this.defaultNamespace + '.' + event;
+            } else {
+                event = event.substr(1);
+            }
         }
 
         return event.replace(/\./g, '\\');


### PR DESCRIPTION
**Fixed a typing issue**
`void` → `PusherChannel`

**Allows default namespace to be omitted.**
This is preferred when using laravel-echo with another framework that doesn't use the Laravel namespacing conventions. 

``` javascript
new Echo({
   namespace: false
});
```

``` javascript
echo.channel('test-channel').listen('test-event') //formatted as test-event
```

Closes https://github.com/laravel/echo/issues/55