### PR TITLE
Refactor EventFormatter to allow for empty namespace

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -54,11 +54,7 @@ export class PusherChannel extends Channel {
         this.pusher = pusher;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter;
-
-        if (this.options.namespace) {
-            this.eventFormatter.namespace(this.options.namespace);
-        }
+        this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -61,11 +61,7 @@ export class SocketIoChannel extends Channel {
         this.socket = socket;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter;
-
-        if (this.options.namespace) {
-            this.eventFormatter.namespace(this.options.namespace);
-        }
+        this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
     }

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -16,7 +16,7 @@ export abstract class Connector {
         csrfToken: null,
         host: null,
         key: null,
-        namespace: ''
+        namespace: 'App.Events'
     };
 
     /**

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -4,11 +4,20 @@
 export class EventFormatter {
 
     /**
-     * Default event namespace.
+     * Event namespace.
      *
      * @type {string}
      */
-    defaultNamespace: string | boolean = 'App.Events';
+    namespace: string | boolean;
+
+    /**
+     * Create a new class instance.
+     *
+     * @params  {string | boolean} namespace
+     */
+    constructor(namespace: string | boolean) {
+        this.setNamespace(namespace);
+    }
 
     /**
      * Format the given event name.
@@ -17,9 +26,9 @@ export class EventFormatter {
      * @return {string}
      */
     format(event: string): string {
-        if (this.defaultNamespace !== false) {
+        if (this.namespace) {
             if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
-                event = this.defaultNamespace + '.' + event;
+                event = this.namespace + '.' + event;
             } else {
                 event = event.substr(1);
             }
@@ -29,12 +38,12 @@ export class EventFormatter {
     }
 
     /**
-     * Set the default event namespace.
+     * Set the event namespace.
      *
      * @param  {string} value
      * @return {void}
      */
-    namespace(value: string): void {
-        this.defaultNamespace = value;
+    setNamespace(value: string | boolean): void {
+        this.namespace = value;
     }
 }


### PR DESCRIPTION
This change allows the use of an empty/false namespace. 
Currently because of [this condition](https://github.com/laravel/echo/blob/master/src/channel/pusher-channel.ts#L59) it is not possible to use an empty/false namespace, which means you have to prepend all your events with a dot.