### PR TITLE
Add global type declaration of axios causing compilation errors

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,3 +3,4 @@
 declare let Pusher: any;
 declare let io: any;
 declare let Vue: any;
+declare let axios: any;


### PR DESCRIPTION
Fixes Visual Studio Code error issue with this repository's tsconfig.

```
36         if (typeof axios === 'function') {
                      ~~~~~

src/echo.ts(36,20): error TS2304: Cannot find name 'axios'.


68         axios.interceptors.request.use((config) => {
           ~~~~~

src/echo.ts(68,9): error TS2304: Cannot find name 'axios'.
```