### PR TITLE
[SocketIO] Subscribe to channel on reconnect

### DIFF
--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -64,7 +64,9 @@ export class SocketIoChannel extends Channel {
         this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
-        socket.on('reconnect', this.subscribe);
+        this.socket.on('reconnect', () => {
+            this.subscribe();
+        });
     }
 
     /**

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -64,9 +64,7 @@ export class SocketIoChannel extends Channel {
         this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
-        socket.on('reconnect', () => {
-            this.subscribe();
-        });
+        socket.on('reconnect', this.subscribe);
     }
 
     /**

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -64,6 +64,9 @@ export class SocketIoChannel extends Channel {
         this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
+        socket.on('reconnect', () => {
+            this.subscribe();
+        });
     }
 
     /**


### PR DESCRIPTION
When a connection is lost (either server is killed or client lost connection) and reconnected, a new socket is created and isn't subscribed.

This adds a reconnect listener to subscribe when a new connection is created. This seems to fix issue https://github.com/tlaverdure/laravel-echo-server/issues/90
I don't know of any other SocketIO servers, so not sure if this is possible to handle server-side otherwise.

/cc @tlaverdure