### PR TITLE
Support client events on Pusher presence channels

### DIFF
--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -46,4 +46,16 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
 
         return this;
     }
+    
+    /**
+     * Trigger client event on the channel.
+     *
+     * @param  {Function}  callback
+     * @return {PusherPresenceChannel}
+     */
+    trigger(eventName, data): PusherPresenceChannel {
+        this.pusher.channels.channels[this.name].trigger(eventName, data);
+
+        return this;
+    }
 }

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -54,7 +54,7 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @return {PusherPresenceChannel}
      */
     trigger(eventName, data): PusherPresenceChannel {
-        this.pusher.channels.channels[this.name].trigger(eventName, data);
+        this.pusher.channels.channels[this.name].trigger(`client-${eventName}`, data);
 
         return this;
     }


### PR DESCRIPTION
This PR adds a `trigger()` method onto the `PusherPresenceChannel` to trigger [a client event](https://pusher.com/docs/client_api_guide/client_events#trigger-events).

This allows the browser to send events directly to Pusher, without having to go through Laravel. It's useful for events such as a "typing..." indicator or other events where it's overkill to pass them through Laravel. In my case it's when a user starts/stops broadcasting video.

See also: https://github.com/laravel/echo/issues/47
