### PR TITLE
Check for jQuery.ajax before jQuery.ajaxSetup

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -82,11 +82,13 @@ class Echo {
      * Register jQuery AjaxSetup to add the X-Socket-ID header.
      */
     registerjQueryAjaxSetup() {
-        jQuery.ajaxSetup({
-            beforeSend: (xhr) => {
-                xhr.setRequestHeader('X-Socket-Id', this.socketId());
-            }
-        });
+        if (typeof jQuery.ajax != 'undefined' ) {
+            jQuery.ajaxSetup({
+                beforeSend: (xhr) => {
+                    xhr.setRequestHeader('X-Socket-Id', this.socketId());
+                }
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Only do jQuery.ajaxSetup if jQuery.ajax is available. It could be that jquery slim is available which does not include the ajax module. Otherwise a "Uncaught TypeError: jQuery.ajaxSetup is not a function" error is thrown and it all comes crashing down.