### PR TITLE
Add sanity check for socketId

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -85,7 +85,9 @@ class Echo {
         if (typeof jQuery.ajax != 'undefined' ) {
             jQuery.ajaxSetup({
                 beforeSend: (xhr) => {
-                    xhr.setRequestHeader('X-Socket-Id', this.socketId());
+					if (this.socketId()) {
+						xhr.setRequestHeader('X-Socket-Id', this.socketId());
+					}
                 }
             });
         }


### PR DESCRIPTION
This fixes the jQuery interceptor. We don't want to add the X-Socket-Id header if the socketId is undefined.

This bug managed to break the Google Maps API through jQuery.