### PR TITLE
Support react-native variant of pusher

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -65,7 +65,7 @@ export abstract class Connector {
             return window['Laravel'].csrfToken;
         } else if (this.options.csrfToken) {
             return this.options.csrfToken;
-        } else if (document && (selector = document.querySelector('meta[name="csrf-token"]'))) {
+        } else if (typeof document !== 'undefined' && (selector = document.querySelector('meta[name="csrf-token"]'))) {
             return selector.getAttribute('content');
         }
 

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -47,6 +47,12 @@ class Echo {
             }
 
             this.connector = new PusherConnector(this.options);
+        } else if (this.options.broadcaster == 'pusher/react-native') {
+                if (!window['Pusher']) {
+                    window['Pusher'] = require('pusher-js/react-native');
+                }
+
+                this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'socket.io') {
             this.connector = new SocketIoConnector(this.options);
         }

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -42,13 +42,13 @@ class Echo {
         }
 
         if (this.options.broadcaster == 'pusher') {
-            if (!window['Pusher']) {
+            if (! window['Pusher']) {
                 window['Pusher'] = require('pusher-js');
             }
 
             this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'pusher/react-native') {
-                if (!window['Pusher']) {
+                if (! window['Pusher']) {
                     window['Pusher'] = require('pusher-js/react-native');
                 }
 


### PR DESCRIPTION
Pusher has a react-native variant which works with RN (default doesn't - tries to use document object).

Also use a more strict document check to avoid a thrown error in RN as document isn't available.