### PR TITLE
Dynamic requiring of pusher libraries.

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -43,16 +43,20 @@ class Echo {
 
         if (this.options.broadcaster == 'pusher') {
             if (! window['Pusher']) {
-                window['Pusher'] = require('pusher-js');
+                let pusherJs = 'pusher-js';
+
+                window['Pusher'] = require('' + pusherJs);
             }
 
             this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'pusher/react-native') {
-                if (! window['Pusher']) {
-                    window['Pusher'] = require('pusher-js/react-native');
-                }
+            if (! window['Pusher']) {
+                let pusherReactNative = 'pusher-js/react-native';
 
-                this.connector = new PusherConnector(this.options);
+                window['Pusher'] = require('' + pusherReactNative);
+            }
+
+            this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'socket.io') {
             this.connector = new SocketIoConnector(this.options);
         }
@@ -88,12 +92,12 @@ class Echo {
      * Register jQuery AjaxSetup to add the X-Socket-ID header.
      */
     registerjQueryAjaxSetup() {
-        if (typeof jQuery.ajax != 'undefined' ) {
+        if (typeof jQuery.ajax != 'undefined') {
             jQuery.ajaxSetup({
                 beforeSend: (xhr) => {
-					if (this.socketId()) {
-						xhr.setRequestHeader('X-Socket-Id', this.socketId());
-					}
+                    if (this.socketId()) {
+                        xhr.setRequestHeader('X-Socket-Id', this.socketId());
+                    }
                 }
             });
         }


### PR DESCRIPTION
By default the [pusher-js ](https://github.com/laravel/echo/blob/99be9119903d679980cadb4d6758cfa9c3b244d5/src/echo.ts#L46) and [pusher/react-native](pusher/react-native) packages are required if the pusher broadcaster is selected. This is causing Webpack to fail if the packages are not installed. I'm opposed to installing additional packages when they are not is use, as that potentially leads to a large bundle size. Webpack as a module bundler does not have access to the `window` object at build time  to determine if these packages should be required or not. 

This is the best solution that I could find and it seems to work as intended.

**Reference:**
https://webpack.github.io/docs/context.html#dynamic-require-rewriting 


Closes https://github.com/laravel/echo/issues/40, https://github.com/laravel/echo/issues/52