### PR TITLE
Remove the pusher libraries.

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -42,20 +42,6 @@ class Echo {
         }
 
         if (this.options.broadcaster == 'pusher') {
-            if (! window['Pusher']) {
-                let pusherJs = 'pusher-js';
-
-                window['Pusher'] = require('' + pusherJs);
-            }
-
-            this.connector = new PusherConnector(this.options);
-        } else if (this.options.broadcaster == 'pusher/react-native') {
-            if (! window['Pusher']) {
-                let pusherReactNative = 'pusher-js/react-native';
-
-                window['Pusher'] = require('' + pusherReactNative);
-            }
-
             this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'socket.io') {
             this.connector = new SocketIoConnector(this.options);


### PR DESCRIPTION
Requiring pusher libraries directly in the laravel-echo is not the best strategy in terms of using pusher, socket.io, or another broadcaster. This PR removes the hardcoded dependency of the pusher client libraries and requires that these packages be added during configuration.  

**This is a small breaking change in terms of setting up echo.**

This will also need to be updated here:
https://laravel.com/docs/5.4/broadcasting#configuration

``` js
import Echo from "laravel-echo"

window.Pusher = require('pusher-js');

window.Echo = new Echo({
    broadcaster: 'pusher',
    key: 'your-pusher-key'
});
```
