### PR TITLE
Temporary fix to allow dot syntax event names.

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -54,7 +54,9 @@ export class PusherChannel extends Channel {
         this.pusher = pusher;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(
+            this.options.namespace, this.options.formatEvents
+        );
 
         this.subscribe();
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -53,7 +53,9 @@ export class SocketIoChannel extends Channel {
         this.name = name;
         this.socket = socket;
         this.options = options;
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(
+            this.options.namespace, this.options.formatEvents
+        );
 
         this.subscribe();
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -16,7 +16,8 @@ export abstract class Connector {
         csrfToken: null,
         host: null,
         key: null,
-        namespace: 'App.Events'
+        namespace: 'App.Events',
+        formatEvents: true
     };
 
     /**

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -11,12 +11,21 @@ export class EventFormatter {
     namespace: string | boolean;
 
     /**
+     * Format event names.
+     *
+     * @param  {boolean}
+     */
+    formatEvents: boolean;
+
+    /**
      * Create a new class instance.
      *
-     * @params  {string | boolean} namespace
+     * @param  {string | boolean} namespace
+     * @param  {boolean} formatEvents
      */
-    constructor(namespace: string | boolean) {
+    constructor(namespace: string | boolean, formatEvents: boolean) {
         this.setNamespace(namespace);
+        this.setFormatEvents(formatEvents);
     }
 
     /**
@@ -34,7 +43,11 @@ export class EventFormatter {
             }
         }
 
-        return event.replace(/\./g, '\\');
+        if (this.formatEvents) {
+            event = event.replace(/\./g, '\\');
+        }
+
+        return event;
     }
 
     /**
@@ -45,5 +58,15 @@ export class EventFormatter {
      */
     setNamespace(value: string | boolean): void {
         this.namespace = value;
+    }
+
+    /**
+     * Set the formatEvents.
+     *
+     * @param  {boolean} value
+     * @return {void}
+     */
+    setFormatEvents(value: boolean): void {
+        this.formatEvents = value;
     }
 }


### PR DESCRIPTION
Please refer to my reasoning here: https://github.com/laravel/echo/issues/119#issuecomment-317623693

> TL;DR Dot syntax `server.created` is not functioning correctly. This PR adds the option `formatEvents`, defaulted to true. Set this option to false to allow the dot syntax to work.

