### PR TITLE
Temporary fix to allow dot syntax event names. 

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -54,7 +54,9 @@ export class PusherChannel extends Channel {
         this.pusher = pusher;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(
+            this.options.namespace, this.options.allowDotSyntax
+        );
 
         this.subscribe();
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -53,7 +53,9 @@ export class SocketIoChannel extends Channel {
         this.name = name;
         this.socket = socket;
         this.options = options;
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(
+            this.options.namespace, this.options.allowDotSyntax
+        );
 
         this.subscribe();
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -16,7 +16,8 @@ export abstract class Connector {
         csrfToken: null,
         host: null,
         key: null,
-        namespace: 'App.Events'
+        namespace: 'App.Events',
+        allowDotSyntax: false
     };
 
     /**

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -11,12 +11,21 @@ export class EventFormatter {
     namespace: string | boolean;
 
     /**
+     * Allow dot syntax.
+     *
+     * @type {boolean}
+     */
+    allowDotSyntax: boolean;
+
+    /**
      * Create a new class instance.
      *
-     * @params  {string | boolean} namespace
+     * @param  {string | boolean} namespace
+     * @param  {boolean} allowDotSyntax
      */
-    constructor(namespace: string | boolean) {
+    constructor(namespace: string | boolean, allowDotSyntax: boolean) {
         this.setNamespace(namespace);
+        this.setAllowDotSyntax(allowDotSyntax);
     }
 
     /**
@@ -34,7 +43,11 @@ export class EventFormatter {
             }
         }
 
-        return event.replace(/\./g, '\\');
+        if (this.allowDotSyntax) {
+            return event;
+        } else {
+            return event.replace(/\./g, '\\');
+        }
     }
 
     /**
@@ -45,5 +58,15 @@ export class EventFormatter {
      */
     setNamespace(value: string | boolean): void {
         this.namespace = value;
+    }
+
+    /**
+     * Set allowDotSyntax.
+     *
+     * @param  {boolean} value
+     * @return {void}
+     */
+    setAllowDotSyntax(value: boolean): void {
+        this.allowDotSyntax = value;
     }
 }


### PR DESCRIPTION
Please refer to my reasoning here: https://github.com/laravel/echo/issues/119#issuecomment-317623693

> TL;DR Dot syntax `server.created` is not functioning correctly. This PR adds the option `allowDotSyntax`, defaulted to `false`. Set this option to `true` to allow the dot syntax to work.

Once we can figure out a valid fix, with proper documentation, that can be noted and released alongside Laravel 5.5 with notes in the upgrade guide.

