### PR TITLE
fixed the dotsyntax bug

### DIFF
--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -26,12 +26,10 @@ export class EventFormatter {
      * @return {string}
      */
     format(event: string): string {
-        if (this.namespace) {
-            if (event.charAt(0) != '\\' && event.charAt(0) != '.') {
-                event = this.namespace + '.' + event;
-            } else {
-                event = event.substr(1);
-            }
+        if (event.charAt(0) === '.' || event.charAt(0) === '\\') {
+            return event.substr(1);
+        } else if (this.namespace) {
+            event = this.namespace + '.' + event;
         }
 
         return event.replace(/\./g, '\\');


### PR DESCRIPTION
Okay, it is a wonder what sleep will do to the brain. All that is needed to fix `server.created` `broadcastAs()` methods was to move the `.replace()` call. I tested this fix with the following configurations:

```
// PHP
namespace App\Events;
class ServerCreated extends Event {}

// JS
let Echo = new Echo();
Echo.listen('ServerCreated', () => {});
```

```
// PHP
namespace App\Events\Server;
class Created extends Event {}

// JS
let Echo = new Echo();
Echo.listen('Server.Created', () => {});
```

```
// PHP
namespace Foobar\Events;
class ServerCreated extends Event {}

// JS
let Echo = new Echo();
Echo.listen('\\Foobar\\Events\\ServerCreated', () => {});
Echo.listen('.Foorbar.Events.ServerCreated', () => {});
```

```
// PHP
namespace App\Events;
class ServerCreated extends Event {
    public function broadcastAs() { return 'server.created'; }
}

// JS
let Echo = new Echo();
Echo.listen('.server.created', () => {});
```

All of these scenarios triggered their event handlers as expected.
