### PR TITLE
Fixed Event Format bug when event start with .

### DIFF
--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -27,7 +27,7 @@ export class EventFormatter {
      */
     format(event: string): string {
         if (event.charAt(0) === '.' || event.charAt(0) === '\\') {
-            return event.substr(1);
+            return this.format(event.substr(1));
         } else if (this.namespace) {
             event = this.namespace + '.' + event;
         }


### PR DESCRIPTION
Notification event format actually works on .listen('.Illuminate\\Notifications\\Events\\BroadcastNotificationCreated', console.log);
**fix event-format.ts or change notification event to '.Illuminate\\Notifications\\Events\\BroadcastNotificationCreated'**