### PR TITLE
Fixed the event signature for Notifications.

### DIFF
--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -26,7 +26,7 @@ export abstract class Channel {
      * @return {Channel}
      */
     notification(callback: Function): Channel {
-        return this.listen('.Illuminate.Notifications.Events.BroadcastNotificationCreated', callback);
+        return this.listen('.Illuminate\\Notifications\\Events\\BroadcastNotificationCreated', callback);
     }
 
     /**


### PR DESCRIPTION
This will resolve the issue for `.notification()` calls using the latest formatter in 1.3.1. Thank you everyone in #137 and #139 for helping contribute to discussing this.

@taylorotwell I know we still need an application to test all these damn scenarios, but this will attach the right event signature to the callback stack for all broadcast notifications.