### PR TITLE
import 'socket.io-client'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "laravel-echo",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Laravel Echo library for beautiful Pusher and Socket.IO integration",
   "main": "dist/echo.js",
   "scripts": {
@@ -12,6 +12,7 @@
     "url": "https://github.com/laravel/echo"
   },
   "keywords": [
+    "ionic",
     "laravel",
     "pusher",
     "socket.io"
@@ -23,7 +24,9 @@
   "engines": {
     "node": ">6.0.*"
   },
-  "dependencies": {},
+  "dependencies": {
+    "socket.io-client": "^2.0.3"
+  },
   "devDependencies": {
     "@types/node": "^6.0.85",
     "babel-plugin-transform-object-assign": "^6.8.0",
@@ -32,6 +35,7 @@
     "pusher-js": "^3.2.1",
     "rollup": "^0.31.0",
     "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-typescript": "^0.7.5"
+    "rollup-plugin-typescript": "^0.7.5",
+    "socket.io-client": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "url": "https://github.com/laravel/echo"
   },
   "keywords": [
-    "ionic",
     "laravel",
     "pusher",
     "socket.io"

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -1,5 +1,6 @@
 import { Connector } from './connector';
 import { SocketIoChannel, SocketIoPrivateChannel, SocketIoPresenceChannel } from './../channel';
+import * as io from 'socket.io-client';
 
 /**
  * This class creates a connnector to a Socket.io server.


### PR DESCRIPTION
Solve problem when import 'laravel-echo' to application and got error "Can't find variable: io", When using `socket.io`.

In Laravel you can manually import by `  window.io = require('socket.io-client');`, But in application like ionic you can't.