### PR TITLE
 Makes echo usable in CLI

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -61,7 +61,7 @@ export abstract class Connector {
     protected csrfToken(): string {
         let selector;
 
-        if (window && window['Laravel'] && window['Laravel'].csrfToken) {
+        if (typeof window !=='undefined' && window['Laravel'] && window['Laravel'].csrfToken) {
             return window['Laravel'].csrfToken;
         } else if (this.options.csrfToken) {
             return this.options.csrfToken;

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -25,7 +25,9 @@ export class SocketIoConnector extends Connector {
      * @return void
      */
     connect(): void {
-        this.socket = io(this.options.host, this.options);
+        let io = this.getSocketIo();
+
+         this.socket = io(this.options.host, this.options);
 
         return this.socket;
     }
@@ -130,5 +132,15 @@ export class SocketIoConnector extends Connector {
      */
     disconnect(): void {
         this.socket.disconnect();
+    }
+
+    getSocketIo(){
+        if(typeof io === 'undefined'){
+            if(this.options.client !== undefined) {
+                return this.options.client;
+            }
+
+            throw new Error('When using echo in node-js cli, pass socket.io-client as `client` option!');
+        }
     }
 }


### PR DESCRIPTION
Hi,

I love Echo and [laravel-echo-server](https://github.com/tlaverdure/laravel-echo-server) and am playing around with socket.io used in a NodeJS cli command.

the socket-io lib could be passed as an echo-option to be flexible and to make it usable in a cli script.

what do you guys think about that?


example usage (run with `node example.js`):

```js
let Echo = require('../laravel-echo/dist/echo.js');

let echo = new Echo({
    broadcaster: 'socket.io'    ,
    host: "ws.my-server.test",
    encrypted: true,
    client: require('socket.io-client'),
    auth: {
        headers: {
            "Authorization": "Bearer xyz"
        }
    },
});

console.log("start echo");

echo.join(`chat`)
    .here((users) => {
        console.log("here:=", users)
        console.log("");
    })
    .joining((user) => {
        console.log( user.username, " joined us");
        console.log("");
    })
    .leaving((user) => {
        console.log(user.username, " left us"); 
        console.log("");
    })
    .listen('NewMessage', (e) => {
        console.log('NewMessage:=', e);
        console.log("");
    });
```


  