### PR TITLE
 Makes echo usable in CLI (fixed)

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -61,7 +61,7 @@ export abstract class Connector {
     protected csrfToken(): string {
         let selector;
 
-        if (window && window['Laravel'] && window['Laravel'].csrfToken) {
+        if (typeof window !== 'undefined' && window['Laravel'] && window['Laravel'].csrfToken) {
             return window['Laravel'].csrfToken;
         } else if (this.options.csrfToken) {
             return this.options.csrfToken;

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -25,6 +25,7 @@ export class SocketIoConnector extends Connector {
      * @return void
      */
     connect(): void {
+        let io = this.getSocketIO();
         this.socket = io(this.options.host, this.options);
 
         return this.socket;
@@ -130,5 +131,22 @@ export class SocketIoConnector extends Connector {
      */
     disconnect(): void {
         this.socket.disconnect();
+    }
+
+    /**
+     * Get socket.io module from global scope or options.
+     *
+     * @type {object}
+     */
+    getSocketIO(): any {
+        if (typeof io === 'undefined') {
+            if (this.options.client !== 'undefined') {
+                return this.options.client;
+            }
+
+            throw new Error('make socket.io client globally available or pass via options.client');
+        }
+        
+        return io;
     }
 }


### PR DESCRIPTION
Sorry for the mistakes in my previous PR(https://github.com/laravel/echo/pull/159)

I hope it now meets the requirements...

Example usage (run with `node example.js`):

```js
let Echo = require('../laravel-echo/dist/echo.js');

let echo = new Echo({
    broadcaster: 'socket.io',
    host: 'ws.my-server.test',
    encrypted: true,
    client: require('socket.io-client'),
    auth: {
        headers: {
            'Authorization': 'Bearer xyz',
        },
    },
});

console.log('start echo');

echo.join(`chat`)
    .here(users => {
        console.log('here(users) : users:=', users);
    })
    .joining(user => {
        console.log('joining(user) : user.username:=', user.username);
    })
    .leaving(user => {
        console.log('leaving(user) : user.username:=', user.username); 
    })
    .listen('NewMessage', event => {
        console.log('listen(NewMessage) : event:=', event);
    });
```


  
  
  
  