### PR TITLE
Fix event formatter bug

### DIFF
--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -27,7 +27,7 @@ export class EventFormatter {
      */
     format(event: string): string {
         if (event.charAt(0) === '.' || event.charAt(0) === '\\') {
-            return event.substr(1);
+            event = event.substr(1);
         } else if (this.namespace) {
             event = this.namespace + '.' + event;
         }


### PR DESCRIPTION
When using a "root" indicator, the dots are never replaced at the end of the function.

So `.App.Foo.Bar` became `App.Foo.Bar` instead of `App\\Foo\\Bar`.

This broke our listeners at https://github.com/spatie/dashboard.spatie.be