### PR TITLE
Add EventFormatter tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 build/
 npm-debug.log
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+    - stable

--- a/package.json
+++ b/package.json
@@ -23,15 +23,31 @@
   "engines": {
     "node": ">6.0.*"
   },
-  "dependencies": {},
   "devDependencies": {
+    "@types/jest": "^22.1.0",
     "@types/node": "^6.0.85",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-stage-2": "^6.5.0",
+    "jest": "^22.1.0",
     "pusher-js": "^3.2.1",
-    "rollup": "^0.31.0",
     "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-typescript": "^0.7.5"
+    "rollup-plugin-typescript": "^0.7.5",
+    "rollup": "^0.31.0",
+    "ts-jest": "^22.0.0"
+  },
+  "jest": {
+    "transform": {
+      "^.+\\.tsx?$": "ts-jest"
+    },
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/echo.js",
   "scripts": {
     "compile": "./node_modules/.bin/rollup -c",
-    "prepublish": "npm run compile"
+    "prepublish": "npm run compile",
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/tests/util/event-formatter.test.ts
+++ b/tests/util/event-formatter.test.ts
@@ -1,0 +1,47 @@
+import { EventFormatter } from '../../src/util';
+
+describe('EventFormatter', () => {
+    let eventFormatter;
+
+    beforeEach(() => {
+        eventFormatter = new EventFormatter('App.Events');
+    });
+
+    test("prepends an event with a namespace and replaces dot separators with backslashes", () => {
+        let formatted = eventFormatter.format("Users.UserCreated");
+
+        expect(formatted).toBe("App\\Events\\Users\\UserCreated");
+    });
+
+    test('does not prepend a namespace when an event starts with a dot', () => {
+        let formatted = eventFormatter.format('.App\\Users\\UserCreated');
+
+        expect(formatted).toBe('App\\Users\\UserCreated');
+    });
+
+    test('does not prepend a namespace when an event starts with a backslash', () => {
+        let formatted = eventFormatter.format('\\App\\Users\\UserCreated');
+
+        expect(formatted).toBe('App\\Users\\UserCreated');
+    });
+
+    test('does not replace dot separators when the event starts with a dot', () => {
+        let formatted = eventFormatter.format('.users.created');
+
+        expect(formatted).toBe('users.created');
+    });
+
+    test('does not replace dot separators when the event starts with a backslash', () => {
+        let formatted = eventFormatter.format('\\users.created');
+
+        expect(formatted).toBe('users.created');
+    });
+
+    test('does not prepend a namespace when none is set', () => {
+        let eventFormatter = new EventFormatter(false);
+
+        let formatted = eventFormatter.format('Users.UserCreated');
+
+        expect(formatted).toBe('Users\\UserCreated');
+    });
+});


### PR DESCRIPTION
This PR adds tests for `EventFormatter` with Jest, I think I've gotten all the rules written down.

The `does not replace dot separators...`  tests were the confusion point in the previous PR's. I always expected dots to be replaced when you do something like `.App.Users.UserCreated`, but I guess that wouldn't play well when using `broadcastAs`. Kind of defeats the intention of #11, but I'll update our Dashboard to just use `broadcastAs`.

Also added a `package.lock` entry to `.gitignore`, so people don't accidentally add this to the repo when using the latest npm version.

Shout if there are any missing test cases, or if there are any other classes you'd like to see tested, I'll gladly add them :)

/cc @mpyw 