### PR TITLE
Add Typings file for project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 build/
 npm-debug.log
 package-lock.json
+.rpt2_cache

--- a/package.json
+++ b/package.json
@@ -28,8 +28,6 @@
   "devDependencies": {
     "@types/jest": "^22.1.0",
     "@types/node": "^6.0.85",
-    "@types/pusher-js": "^4.2.0",
-    "@types/socket.io-client": "^1.4.32",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-stage-2": "^6.5.0",
@@ -40,6 +38,10 @@
     "rollup-plugin-typescript2": "^0.17.2",
     "ts-jest": "^22.0.0",
     "typescript": "^3.1.6"
+  },
+  "dependencies": {
+    "@types/pusher-js": "^4.2.0",
+    "@types/socket.io-client": "^1.4.32"
   },
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.0",
   "description": "Laravel Echo library for beautiful Pusher and Socket.IO integration",
   "main": "dist/echo.js",
+  "typings": "dist/types/echo.d.ts",
   "scripts": {
     "compile": "./node_modules/.bin/rollup -c",
     "prepublish": "npm run compile",
@@ -32,15 +33,17 @@
     "babel-preset-stage-2": "^6.5.0",
     "jest": "^22.1.0",
     "pusher-js": "^3.2.1",
+    "rollup": "^0.66.2",
     "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-typescript": "^0.7.5",
-    "rollup": "^0.31.0",
-    "ts-jest": "^22.0.0"
+    "rollup-plugin-typescript2": "^0.17.2",
+    "ts-jest": "^22.0.0",
+    "typescript": "^3.1.6"
   },
   "jest": {
     "transform": {
       "^.+\\.tsx?$": "ts-jest"
     },
+    "testURL": "http://localhost",
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
     "moduleFileExtensions": [
       "ts",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "devDependencies": {
     "@types/jest": "^22.1.0",
     "@types/node": "^6.0.85",
+    "@types/pusher-js": "^4.2.0",
+    "@types/socket.io-client": "^1.4.32",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015-rollup": "^3.0.0",
     "babel-preset-stage-2": "^6.5.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,20 @@
-import typescript from 'rollup-plugin-typescript';
 import babel from 'rollup-plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
 
 export default {
-  entry: './src/echo.ts',
-  dest: './dist/echo.js',
-  plugins: [
-    typescript(),
-    babel({
-      exclude: 'node_modules/**',
-      presets: ['es2015-rollup', 'stage-2'],
-      plugins: ['transform-object-assign']
-    })
-  ]
+    input: './src/echo.ts',
+    output: [{
+        file: 'dist/echo.js',
+        format: 'cjs'
+    }],
+    plugins: [
+        typescript({
+            useTsconfigDeclarationDir: true
+        }),
+        babel({
+            exclude: 'node_modules/**',
+            presets: ['es2015-rollup', 'stage-2'],
+            plugins: ['transform-object-assign']
+        })
+    ]
 }

--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -1,3 +1,5 @@
+import EchoOptions from "../echoOptions";
+
 /**
  * This class represents a basic channel.
  */
@@ -7,7 +9,7 @@ export abstract class Channel {
      *
      * @type {any}
      */
-    options: any;
+    options!: EchoOptions;
 
     /**
      * Listen for an event on the channel instance.

--- a/src/channel/null-presence-channel.ts
+++ b/src/channel/null-presence-channel.ts
@@ -11,7 +11,7 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
      * @param  {Function} callback
      * @return {object} this
      */
-    here(callback): NullPresenceChannel {
+    here(callback: Function): NullPresenceChannel {
         return this;
     }
 
@@ -21,7 +21,7 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
      * @param  {Function} callback
      * @return {NullPresenceChannel}
      */
-    joining(callback): NullPresenceChannel {
+    joining(callback: Function): NullPresenceChannel {
         return this;
     }
 
@@ -31,7 +31,7 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
      * @param  {Function}  callback
      * @return {NullPresenceChannel}
      */
-    leaving(callback): NullPresenceChannel {
+    leaving(callback: Function): NullPresenceChannel {
         return this;
     }
 
@@ -41,7 +41,7 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
      * @param  {Function}  callback
      * @return {NullPresenceChannel}
      */
-    whisper(eventName, data): NullPresenceChannel {
+    whisper(eventName: any, data: any): NullPresenceChannel {
         return this;
     }
 }

--- a/src/channel/null-private-channel.ts
+++ b/src/channel/null-private-channel.ts
@@ -10,7 +10,7 @@ export class NullPrivateChannel extends NullChannel {
      * @param  {Function}  callback
      * @return {NullPrivateChannel}
      */
-    whisper(eventName, data): NullPrivateChannel {
+    whisper(eventName: any, data: any): NullPrivateChannel {
         return this;
     }
 }

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -55,7 +55,7 @@ export class PusherChannel extends Channel {
         this.pusher = pusher;
         this.options = options;
 
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(<string | boolean>this.options.namespace);
 
         this.subscribe();
     }

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -1,5 +1,6 @@
 import { EventFormatter } from './../util';
 import { Channel } from './channel';
+import EchoOptions from '../echoOptions';
 
 /**
  * This class represents a Pusher channel.
@@ -8,23 +9,23 @@ export class PusherChannel extends Channel {
     /**
      * The Pusher client instance.
      *
-     * @type {any}
+     * @type {Pusher.Pusher}
      */
-    pusher: any;
+    pusher: Pusher.Pusher;
 
     /**
      * The name of the channel.
      *
-     * @type {object}
+     * @type {string}
      */
-    name: any;
+    name: string;
 
     /**
      * Channel options.
      *
-     * @type {any}
+     * @type {EchoOptions}
      */
-    options: any;
+    options: EchoOptions;
 
     /**
      * The event formatter.
@@ -38,16 +39,16 @@ export class PusherChannel extends Channel {
      *
      * @type {any}
      */
-    subscription: any;
+    subscription!: Pusher.Channel;
 
     /**
      * Create a new class instance.
      *
-     * @param  {any} pusher
-     * @param  {object} name
-     * @param  {any}  options
+     * @param  {Pusher.Pusher} pusher
+     * @param  {string} name
+     * @param  {EchoOptions}  options
      */
-    constructor(pusher: any, name: any, options: any) {
+    constructor(pusher: Pusher.Pusher, name: string, options: EchoOptions) {
         super();
 
         this.name = name;
@@ -85,7 +86,7 @@ export class PusherChannel extends Channel {
      * @param  {Function}   callback
      * @return {PusherChannel}
      */
-    listen(event: string, callback: Function): PusherChannel {
+    listen(event: string, callback: Pusher.EventCallback): PusherChannel {
         this.on(this.eventFormatter.format(event), callback);
 
         return this;
@@ -110,7 +111,7 @@ export class PusherChannel extends Channel {
      * @param  {Function} callback
      * @return {void}
      */
-    on(event: string, callback: Function): PusherChannel {
+    on(event: string, callback: Pusher.EventCallback): PusherChannel {
         this.subscription.bind(event, callback);
 
         return this;

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -11,8 +11,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @param  {Function} callback
      * @return {object} this
      */
-    here(callback): PusherPresenceChannel {
-        this.on('pusher:subscription_succeeded', (data) => {
+    here(callback: Function): PusherPresenceChannel {
+        this.on('pusher:subscription_succeeded', (data: any) => {
             callback(Object.keys(data.members).map(k => data.members[k]));
         });
 
@@ -25,8 +25,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @param  {Function} callback
      * @return {PusherPresenceChannel}
      */
-    joining(callback): PusherPresenceChannel {
-        this.on('pusher:member_added', (member) => {
+    joining(callback: Function): PusherPresenceChannel {
+        this.on('pusher:member_added', (member: any) => {
             callback(member.info);
         });
 
@@ -39,8 +39,8 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @param  {Function}  callback
      * @return {PusherPresenceChannel}
      */
-    leaving(callback): PusherPresenceChannel {
-        this.on('pusher:member_removed', (member) => {
+    leaving(callback: Function): PusherPresenceChannel {
+        this.on('pusher:member_removed', (member: any) => {
             callback(member.info);
         });
 
@@ -53,7 +53,7 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
      * @param  {Function}  callback
      * @return {PusherPresenceChannel}
      */
-    whisper(eventName, data): PusherPresenceChannel {
+    whisper(eventName: any, data: any): PusherPresenceChannel {
         this.pusher.channels.channels[this.name].trigger(`client-${eventName}`, data);
 
         return this;

--- a/src/channel/pusher-private-channel.ts
+++ b/src/channel/pusher-private-channel.ts
@@ -10,7 +10,7 @@ export class PusherPrivateChannel extends PusherChannel {
      * @param  {Function}  callback
      * @return {PusherPrivateChannel}
      */
-    whisper(eventName, data): PusherPrivateChannel {
+    whisper(eventName: any, data: any): PusherPrivateChannel {
         this.pusher.channels.channels[this.name].trigger(`client-${eventName}`, data);
 
         return this;

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -48,13 +48,13 @@ export class SocketIoChannel extends Channel {
      * @param  {string} name
      * @param  {any} options
      */
-    constructor(socket: any, name: string, options: any) {
+    constructor(socket: any, name: string, options: EchoOptions) {
         super();
 
         this.name = name;
         this.socket = socket;
         this.options = options;
-        this.eventFormatter = new EventFormatter(this.options.namespace);
+        this.eventFormatter = new EventFormatter(<string | boolean>this.options.namespace);
 
         this.subscribe();
 

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -1,5 +1,6 @@
 import { EventFormatter } from './../util';
 import { Channel } from './channel';
+import EchoOptions from '../echoOptions';
 
 /**
  * This class represents a Socket.io channel.
@@ -10,21 +11,21 @@ export class SocketIoChannel extends Channel {
      *
      * @type {any}
      */
-    socket: any;
+    socket: SocketIOClient.Socket;
 
     /**
      * The name of the channel.
      *
      * @type {object}
      */
-    name: any;
+    name: string;
 
     /**
      * Channel options.
      *
      * @type {any}
      */
-    options: any;
+    options: EchoOptions;
 
     /**
      * The event formatter.
@@ -38,7 +39,7 @@ export class SocketIoChannel extends Channel {
      *
      * @type {any}
      */
-    events: any = {};
+    events: { [key: string]: Function[] } = {};
 
     /**
      * Create a new class instance.
@@ -106,7 +107,7 @@ export class SocketIoChannel extends Channel {
      * @param  {Function} callback
      */
     on(event: string, callback: Function): void {
-        let listener = (channel, data) => {
+        let listener = (channel: any, data: any) => {
             if (this.name == channel) {
                 callback(data);
             }
@@ -149,7 +150,7 @@ export class SocketIoChannel extends Channel {
      */
     unbind(): void {
         Object.keys(this.events).forEach(event => {
-            this.events[event].forEach(callback => {
+            this.events[event].forEach((callback: Function) => {
                 this.socket.removeListener(event, callback);
             });
 

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -11,8 +11,8 @@ export class SocketIoPresenceChannel extends SocketIoPrivateChannel implements P
      * @return {object} SocketIoPresenceChannel
      */
     here(callback: Function): SocketIoPresenceChannel {
-        this.on('presence:subscribed', (members) => {
-            callback(members.map(m => m.user_info));
+        this.on('presence:subscribed', (members: any) => {
+            callback(members.map((m: any) => m.user_info));
         });
 
         return this;
@@ -25,7 +25,7 @@ export class SocketIoPresenceChannel extends SocketIoPrivateChannel implements P
      * @return {SocketIoPresenceChannel}
      */
     joining(callback: Function): SocketIoPresenceChannel {
-        this.on('presence:joining', (member) => callback(member.user_info));
+        this.on('presence:joining', (member: any) => callback(member.user_info));
 
         return this;
     }
@@ -37,7 +37,7 @@ export class SocketIoPresenceChannel extends SocketIoPrivateChannel implements P
      * @return {SocketIoPresenceChannel}
      */
     leaving(callback: Function): SocketIoPresenceChannel {
-        this.on('presence:leaving', (member) => callback(member.user_info));
+        this.on('presence:leaving', (member: any) => callback(member.user_info));
 
         return this;
     }

--- a/src/channel/socketio-private-channel.ts
+++ b/src/channel/socketio-private-channel.ts
@@ -11,7 +11,7 @@ export class SocketIoPrivateChannel extends SocketIoChannel {
      * @param  {object}  data
      * @return {PusherPrivateChannel}
      */
-    whisper(eventName, data) {
+    whisper(eventName: any, data: any) {
         this.socket.emit('client event', {
             channel: this.name,
             event: `client-${eventName}`,

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -48,7 +48,7 @@ export abstract class Connector {
         this.options = Object.assign(this._defaultOptions, options);
 
         if (this.csrfToken()) {
-            this.options.auth.headers!['X-CSRF-TOKEN'] = this.csrfToken();
+            this.options.auth!.headers!['X-CSRF-TOKEN'] = this.csrfToken();
         }
 
         return options;

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -1,4 +1,5 @@
 import { Channel, PresenceChannel } from './../channel';
+import EchoOptions from '../echoOptions'
 
 export abstract class Connector {
 
@@ -22,16 +23,16 @@ export abstract class Connector {
     /**
      * Connector options.
      *
-     * @type {object}
+     * @type {EchoOptions}
      */
-    options: any;
+    options!: EchoOptions;
 
     /**
      * Create a new class instance.
      *
      * @params  {any} options
      */
-    constructor(options: any) {
+    constructor(options: EchoOptions) {
         this.setOptions(options);
 
         this.connect();
@@ -43,11 +44,11 @@ export abstract class Connector {
      * @param  {any}  options
      * @return {any}
      */
-    protected setOptions(options: any): any {
+    protected setOptions(options: EchoOptions): any {
         this.options = Object.assign(this._defaultOptions, options);
 
         if (this.csrfToken()) {
-            this.options.auth.headers['X-CSRF-TOKEN'] = this.csrfToken();
+            this.options.auth.headers!['X-CSRF-TOKEN'] = this.csrfToken();
         }
 
         return options;
@@ -56,13 +57,13 @@ export abstract class Connector {
     /**
      * Extract the CSRF token from the page.
      *
-     * @return {string}
+     * @return {string | null}
      */
-    protected csrfToken(): string {
+    protected csrfToken(): string | null {
         let selector;
 
-        if (typeof window !== 'undefined' && window['Laravel'] && window['Laravel'].csrfToken) {
-            return window['Laravel'].csrfToken;
+        if (typeof window !== 'undefined' && (<any>window)['Laravel'] && (<any>window)['Laravel'].csrfToken) {
+            return (<any>window)['Laravel'].csrfToken;
         } else if (this.options.csrfToken) {
             return this.options.csrfToken;
         } else if (typeof document !== 'undefined' && (selector = document.querySelector('meta[name="csrf-token"]'))) {
@@ -78,6 +79,16 @@ export abstract class Connector {
      * @retrn void
      */
     abstract connect(): void;
+
+    /**
+     * Listen for an event on a channel instance.
+     *
+     * @param  {string} name
+     * @param  {event} string
+     * @param  {Function} callback
+     * @return {Channel}
+     */
+    abstract listen(name: string, event: string, callback: Function): Channel;
 
     /**
      * Get a channel instance by name.

--- a/src/connector/null-connector.ts
+++ b/src/connector/null-connector.ts
@@ -1,4 +1,4 @@
-import { Connector} from './connector';
+import { Connector } from './connector';
 import {
     NullChannel, NullPrivateChannel, NullPresenceChannel, PresenceChannel
 } from './../channel';

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -1,7 +1,8 @@
 import { Connector} from './connector';
 import {
-    PusherChannel, PusherPrivateChannel, PusherPresenceChannel, PresenceChannel
+    PusherChannel, PusherPrivateChannel, PusherPresenceChannel, PresenceChannel, Channel
 } from './../channel';
+import { PusherStatic } from 'pusher-js';
 
 /**
  * This class creates a connector to Pusher.
@@ -12,14 +13,14 @@ export class PusherConnector extends Connector {
      *
      * @type {object}
      */
-    pusher: any;
+    pusher!: Pusher.Pusher;
 
     /**
      * All of the subscribed channel names.
      *
      * @type {array}
      */
-    channels: any = {};
+    channels: { [key: string]: PusherChannel } = {};
 
     /**
      * Create a fresh Pusher connection.
@@ -28,9 +29,9 @@ export class PusherConnector extends Connector {
      */
     connect(): void {
         if (typeof this.options.client !== 'undefined') {
-            this.pusher = this.options.client;
+            this.pusher = <Pusher.Pusher>this.options.client;
         } else {
-            this.pusher = new Pusher(this.options.key, this.options);
+            this.pusher = new (<any>window).Pusher(this.options.key!, this.options);
         }
     }
 
@@ -42,7 +43,7 @@ export class PusherConnector extends Connector {
      * @param  {Function} callback
      * @return {PusherChannel}
      */
-    listen(name: string, event: string, callback: Function): PusherChannel {
+    listen(name: string, event: string, callback: Pusher.EventCallback): PusherChannel {
         return this.channel(name).listen(event, callback);
     }
 
@@ -86,9 +87,9 @@ export class PusherConnector extends Connector {
      * Get a presence channel instance by name.
      *
      * @param  {string} name
-     * @return {PresenceChannel}
+     * @return {PusherPresenceChannel}
      */
-    presenceChannel(name: string): PresenceChannel {
+    presenceChannel(name: string): PusherPresenceChannel {
         if (!this.channels['presence-' + name]) {
             this.channels['presence-' + name] = new PusherPresenceChannel(
                 this.pusher,
@@ -97,7 +98,7 @@ export class PusherConnector extends Connector {
             );
         }
 
-        return this.channels['presence-' + name];
+        return (<PusherPresenceChannel>this.channels['presence-' + name]);
     }
 
     /**

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -10,21 +10,21 @@ export class SocketIoConnector extends Connector {
      *
      * @type {object}
      */
-    socket: any;
+    socket!: SocketIOClient.Socket;
 
     /**
      * All of the subscribed channel names.
      *
      * @type {any}
      */
-    channels: any = {};
+    channels: { [key: string]: SocketIoChannel } = {};
 
     /**
      * Create a fresh Socket.io connection.
      *
-     * @return void
+     * @return SocketIOClient.Socket
      */
-    connect(): void {
+    connect(): SocketIOClient.Socket {
         let io = this.getSocketIO();
 
         this.socket = io(this.options.host, this.options);
@@ -94,7 +94,7 @@ export class SocketIoConnector extends Connector {
             );
         }
 
-        return this.channels['private-' + name];
+        return <SocketIoPrivateChannel>this.channels['private-' + name];
     }
 
     /**
@@ -112,7 +112,7 @@ export class SocketIoConnector extends Connector {
             );
         }
 
-        return this.channels['presence-' + name];
+        return <SocketIoPresenceChannel>this.channels['presence-' + name];
     }
 
     /**

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,5 +1,7 @@
+import { Connector } from './connector';
 import { EventFormatter } from './util';
 import { Channel, PresenceChannel } from './channel'
+import EchoOptions from './echoOptions'
 import { PusherConnector, SocketIoConnector, NullConnector } from './connector';
 
 /**
@@ -12,32 +14,32 @@ export default class Echo {
      *
      * @type {object}
      */
-    connector: any;
+    connector!: Connector;
 
     /**
      * The Echo options.
      *
      * @type {array}
      */
-    options: any;
+    options: EchoOptions;
 
     /**
      * Create a new class instance.
      *
      * @param  {object} options
      */
-    constructor(options: any) {
+    constructor(options: EchoOptions) {
         this.options = options;
 
-        if (typeof Vue === 'function' && Vue.http) {
+        if (typeof (<any>window).Vue === 'function' && (<any>window).Vue.http) {
             this.registerVueRequestInterceptor();
         }
 
-        if (typeof axios === 'function') {
+        if (typeof (<any>window).axios === 'function') {
             this.registerAxiosRequestInterceptor();
         }
 
-        if (typeof jQuery === 'function') {
+        if (typeof (<any>window).jQuery === 'function') {
             this.registerjQueryAjaxSetup();
         }
 
@@ -54,7 +56,7 @@ export default class Echo {
      * Register a Vue HTTP interceptor to add the X-Socket-ID header.
      */
     registerVueRequestInterceptor() {
-        Vue.http.interceptors.push((request, next) => {
+        (<any>window).Vue.http.interceptors.push((request: any, next: any) => {
             if (this.socketId()) {
                 request.headers.set('X-Socket-ID', this.socketId());
             }
@@ -67,7 +69,7 @@ export default class Echo {
      * Register an Axios HTTP interceptor to add the X-Socket-ID header.
      */
     registerAxiosRequestInterceptor() {
-        axios.interceptors.request.use((config) => {
+        (<any>window).axios.interceptors.request.use((config: any) => {
             if (this.socketId()) {
                 config.headers['X-Socket-Id'] = this.socketId();
             }
@@ -80,9 +82,9 @@ export default class Echo {
      * Register jQuery AjaxSetup to add the X-Socket-ID header.
      */
     registerjQueryAjaxSetup() {
-        if (typeof jQuery.ajax != 'undefined') {
-            jQuery.ajaxSetup({
-                beforeSend: (xhr) => {
+        if (typeof (<any>window).jQuery.ajax != 'undefined') {
+            (<any>window).jQuery.ajaxSetup({
+                beforeSend: (xhr: any) => {
                     if (this.socketId()) {
                         xhr.setRequestHeader('X-Socket-Id', this.socketId());
                     }

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -5,7 +5,7 @@ import { PusherConnector, SocketIoConnector, NullConnector } from './connector';
 /**
  * This class is the primary API for interacting with broadcasting.
  */
-class Echo {
+export default class Echo {
 
     /**
      * The broadcasting connector.
@@ -155,5 +155,3 @@ class Echo {
         this.connector.disconnect();
     }
 }
-
-module.exports = Echo;

--- a/src/echoOptions.ts
+++ b/src/echoOptions.ts
@@ -1,7 +1,7 @@
 import { AuthConfig, Config } from "pusher-js";
 
 export default interface EchoOptions extends Config, SocketIOClient.ConnectOpts {
-    namespace?: string,
+    namespace?: string | boolean,
     authEndpoint?: string,
     broadcaster?: string,
     csrfToken?: string | null,

--- a/src/echoOptions.ts
+++ b/src/echoOptions.ts
@@ -1,6 +1,6 @@
-import { PusherStatic, AuthConfig } from "pusher-js";
+import { AuthConfig, Config } from "pusher-js";
 
-export default interface EchoOptions extends PusherStatic, SocketIOClient.ConnectOpts {
+export default interface EchoOptions extends Config, SocketIOClient.ConnectOpts {
     namespace?: string,
     authEndpoint?: string,
     broadcaster?: string,

--- a/src/echoOptions.ts
+++ b/src/echoOptions.ts
@@ -1,12 +1,12 @@
 import { PusherStatic, AuthConfig } from "pusher-js";
 
 export default interface EchoOptions extends PusherStatic, SocketIOClient.ConnectOpts {
-    namespace: string,
-    authEndpoint: string,
-    broadcaster: string,
-    csrfToken: string | null,
-    host: string | undefined,
-    key: string | undefined,
+    namespace?: string,
+    authEndpoint?: string,
+    broadcaster?: string,
+    csrfToken?: string | null,
+    host?: string | undefined,
+    key?: string | undefined,
     client?: Pusher.Pusher | SocketIOClient.Socket,
-    auth: AuthConfig
+    auth?: AuthConfig
 }

--- a/src/echoOptions.ts
+++ b/src/echoOptions.ts
@@ -1,0 +1,12 @@
+import { PusherStatic, AuthConfig } from "pusher-js";
+
+export default interface EchoOptions extends PusherStatic, SocketIOClient.ConnectOpts {
+    namespace: string,
+    authEndpoint: string,
+    broadcaster: string,
+    csrfToken: string | null,
+    host: string | undefined,
+    key: string | undefined,
+    client?: Pusher.Pusher | SocketIOClient.Socket,
+    auth: AuthConfig
+}

--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -8,7 +8,7 @@ export class EventFormatter {
      *
      * @type {string}
      */
-    namespace: string | boolean;
+    namespace!: string | boolean;
 
     /**
      * Create a new class instance.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,8 @@
         "typings/browser",
         "typings/browser.d.ts"
     ],
-    "files": [
-      "src/echo.ts"
+    "include": [
+        "src/**/*"
     ],
     "compileOnSave": false,
     "buildOnSave": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,11 +7,12 @@
         "isolatedModules": false,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "noImplicitAny": false,
+        "strict": true,
+        // "noImplicitAny": true,
         "noImplicitUseStrict": false,
         "noLib": false,
         "preserveConstEnums": true,
-        "suppressImplicitAnyIndexErrors": true,
+        // "suppressImplicitAnyIndexErrors": true,
         "pretty": true,
         "declaration": true,
         "declarationDir": "dist/types"
@@ -22,7 +23,6 @@
         "typings/browser.d.ts"
     ],
     "files": [
-      "typings/index.d.ts",
       "src/echo.ts"
     ],
     "compileOnSave": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,14 +7,14 @@
         "isolatedModules": false,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
-        "declaration": false,
         "noImplicitAny": false,
         "noImplicitUseStrict": false,
         "noLib": false,
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true,
         "pretty": true,
-        "outDir": "build"
+        "declaration": true,
+        "declarationDir": "dist/types"
     },
     "exclude": [
         "node_modules/*",

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,5 +1,0 @@
-declare let Pusher: any;
-declare let io: any;
-declare let Vue: any;
-declare let axios: any;
-declare let jQuery: any;


### PR DESCRIPTION
Try to fix #84 

I update rollup and replace `rollup-plugin-typescript` to `rollup-plugin-typescript2`.
Typescript strict mode true and add typings option.
Add @types/pusher-js @types/socket.io-client dependencies because can get more autocomplete.

Maintain compatibility and not breaking change.
prove about compile after diff:
original https://github.com/yoyo930021/echo/blob/release/dist/echo_common.js
modified https://github.com/yoyo930021/echo/blob/release/dist/echo.js

Example and test project:
https://github.com/yoyo930021/echo-example