### PR TITLE
Add commonjs output to distribution.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "laravel-echo",
   "version": "1.4.2",
   "description": "Laravel Echo library for beautiful Pusher and Socket.IO integration",
-  "main": "dist/echo.js",
+  "main": "dist/echo.common.js",
+  "module": "dist/echo.js",
   "scripts": {
     "build": "npm run compile && npm run declarations",
     "compile": "./node_modules/.bin/rollup -c",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,10 @@ import babel from 'rollup-plugin-babel';
 
 export default {
   input: './src/echo.ts',
-  output: [{ file: './dist/echo.js', format: 'esm' }],
+  output: [
+      { file: './dist/echo.js', format: 'esm' },
+      { file: './dist/echo.common.js', format: 'cjs' },
+  ],
   plugins: [
     typescript(),
     babel({


### PR DESCRIPTION
Some developers are using this package server side, without a bundler like Webpack. This includes a CommonJs output as the [main](https://docs.npmjs.com/files/package.json#main) module for those cases, and ES6 exports should still be discovered using the `module` property of the package.json file.

Both should work depending on the build tools the developer is using. For example, Rollup and Webpack use this field to determine which is appropriate.

```js
import Echo from "laravel-echo"
```

```js
const Echo = require("laravel-echo");
```

Addresses: https://github.com/laravel/echo/issues/211