### PR TITLE
[1.0] Add leaveOne method to connectors

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -81,9 +81,14 @@ export abstract class Connector {
     abstract presenceChannel(channel: string): PresenceChannel;
 
     /**
-     * Leave the given channel.
+     * Leave the given channel and its private & presence channels.
      */
     abstract leave(channel: string): void;
+
+    /**
+     * Leave the given channel.
+     */
+    abstract leaveOne(channel: string): void;
 
     /**
      * Get the socket_id of the connection.

--- a/src/connector/null-connector.ts
+++ b/src/connector/null-connector.ts
@@ -50,7 +50,7 @@ export class NullConnector extends Connector {
     /**
      * Leave the given channel.
      */
-    leave(name: string) {
+    leave(name: string): void {
         //
     }
 

--- a/src/connector/null-connector.ts
+++ b/src/connector/null-connector.ts
@@ -48,9 +48,16 @@ export class NullConnector extends Connector {
     }
 
     /**
-     * Leave the given channel.
+     * Leave the given channel and its private & presence channels.
      */
     leave(name: string): void {
+        //
+    }
+
+    /**
+     * Leave the given channel.
+     */
+    leaveOne(name: string): void {
         //
     }
 

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -81,18 +81,25 @@ export class PusherConnector extends Connector {
     }
 
     /**
-     * Leave the given channel.
+     * Leave the given channel and its private & presence channels.
      */
     leave(name: string): void {
         let channels = [name, 'private-' + name, 'presence-' + name];
 
         channels.forEach((name: string, index: number) => {
-            if (this.channels[name]) {
-                this.channels[name].unsubscribe();
-
-                delete this.channels[name];
-            }
+            this.leaveOne(name);
         });
+    }
+
+    /**
+     * Leave the given channel.
+     */
+    leaveOne(name: string): void {
+        if (this.channels[name]) {
+            this.channels[name].unsubscribe();
+
+            delete this.channels[name];
+        }
     }
 
     /**

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -83,7 +83,7 @@ export class PusherConnector extends Connector {
     /**
      * Leave the given channel.
      */
-    leave(name: string) {
+    leave(name: string): void {
         let channels = [name, 'private-' + name, 'presence-' + name];
 
         channels.forEach((name: string, index: number) => {

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -94,18 +94,25 @@ export class SocketIoConnector extends Connector {
     }
 
     /**
-     * Leave the given channel.
+     * Leave the given channel and its private & presence channels.
      */
     leave(name: string): void {
         let channels = [name, 'private-' + name, 'presence-' + name];
 
         channels.forEach(name => {
-            if (this.channels[name]) {
-                this.channels[name].unsubscribe();
-
-                delete this.channels[name];
-            }
+            this.leaveOne(name);
         });
+    }
+
+    /**
+     * Leave the given channel.
+     */
+    leaveOne(name: string): void {
+        if (this.channels[name]) {
+            this.channels[name].unsubscribe();
+
+            delete this.channels[name];
+        }
     }
 
     /**


### PR DESCRIPTION
At the moment it's impossible to only leave a public channel and not a presence or private channel. With this method people can use it for this behavior if they want.

Closes #202