### PR TITLE
[1.0] Add reference to TS declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.2",
   "description": "Laravel Echo library for beautiful Pusher and Socket.IO integration",
   "main": "dist/echo.common.js",
+  "types": "dist/echo.d.ts",
   "module": "dist/echo.js",
   "scripts": {
     "build": "npm run compile && npm run declarations",


### PR DESCRIPTION
Rollup is creating a TS declaration file (.d.ts), but since this file
isn't referenced by package.json it will not be used if you include
laravel-echo in a TS project (and thus will make this library useless
for TS projects).