### PR TITLE
[1.0] Fix SecurityError in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testURL": "http://localhost",
     "moduleFileExtensions": [
       "ts",
       "tsx",


### PR DESCRIPTION
Was hitting the below error in the tests which was solved by setting the testURL option.

Reference: https://github.com/jsdom/jsdom/issues/2304

Travis can be enabled for this repo after this merge.