### PR TITLE
fix: ensure passed param wins over global

### DIFF
--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -30,12 +30,12 @@ export class SocketIoConnector extends Connector {
      * Get socket.io module from global scope or options.
      */
     getSocketIO(): any {
-        if (typeof io !== 'undefined') {
-            return io;
-        }
-
         if (typeof this.options.client !== 'undefined') {
             return this.options.client;
+        }
+
+        if (typeof io !== 'undefined') {
+            return io;
         }
 
         throw new Error('Socket.io client not found. Should be globally available or passed via options.client');


### PR DESCRIPTION
Fixes: #234

**Currently it's**: Check whether there is a global thing and use that and ignore the parameter.

**With this it's:** Check whether there's a parameter and use that instead of the global thing.

**Reasoning is**: There is some global io we can't control. When something is explicitly passed it should be used.
