### PR TITLE
Added listen methods to presence channels and interface - prevent Angular build errors

### DIFF
--- a/src/channel/null-presence-channel.ts
+++ b/src/channel/null-presence-channel.ts
@@ -32,4 +32,12 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
     whisper(eventName: string, data: any): NullPresenceChannel {
         return this;
     }
+
+    /**
+     * Listen for an event on the channel instance.
+     */
+    listen(event: string, callback: Function): NullPresenceChannel {
+        return this;
+    }
+
 }

--- a/src/channel/null-presence-channel.ts
+++ b/src/channel/null-presence-channel.ts
@@ -39,5 +39,4 @@ export class NullPresenceChannel extends NullChannel implements PresenceChannel 
     listen(event: string, callback: Function): NullPresenceChannel {
         return this;
     }
-
 }

--- a/src/channel/presence-channel.ts
+++ b/src/channel/presence-channel.ts
@@ -1,3 +1,4 @@
+
 /**
  * This interface represents a presence channel.
  */
@@ -16,4 +17,6 @@ export interface PresenceChannel {
      * Listen for someone leaving the channel.
      */
     leaving(callback: Function): PresenceChannel;
+
+    listen(event: string, callback: Function): PresenceChannel;
 }

--- a/src/channel/presence-channel.ts
+++ b/src/channel/presence-channel.ts
@@ -1,4 +1,3 @@
-
 /**
  * This interface represents a presence channel.
  */

--- a/src/channel/pusher-presence-channel.ts
+++ b/src/channel/pusher-presence-channel.ts
@@ -46,4 +46,11 @@ export class PusherPresenceChannel extends PusherChannel implements PresenceChan
 
         return this;
     }
+
+    /**
+     * Listen for an event on the channel instance.
+     */
+    listen(event: string, callback: Function): PusherPresenceChannel {
+        return this;
+    }
 }

--- a/src/channel/socketio-presence-channel.ts
+++ b/src/channel/socketio-presence-channel.ts
@@ -33,4 +33,11 @@ export class SocketIoPresenceChannel extends SocketIoPrivateChannel implements P
 
         return this;
     }
+
+    /**
+     * Listen for an event on the channel instance.
+     */
+    listen(event: string, callback: Function): SocketIoPresenceChannel {
+        return this;
+    }
 }


### PR DESCRIPTION
@driesvints this is most likely not the correct solution, but it does prevent the errors which are stopping the build from succeeding when using Angular CLI.  You will see I just added the listen method to the various PresenceChannels.

I hope this helps!