### PR TITLE
[1.x] Try to get CSRF token from cookie

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -50,9 +50,9 @@ export abstract class Connector {
         let cookie;
 
         const readCookie = function(name) {
-          var match = document.cookie.match(new RegExp('(^|;\\s*)(' + name + ')=([^;]*)'));
-          return (match ? decodeURIComponent(match[3]) : null);
-        },
+            var match = document.cookie.match(new RegExp('(^|;\\s*)(' + name + ')=([^;]*)'));
+            return match ? decodeURIComponent(match[3]) : null;
+        };
 
         if (typeof window !== 'undefined' && window['Laravel'] && window['Laravel'].csrfToken) {
             return window['Laravel'].csrfToken;
@@ -60,7 +60,11 @@ export abstract class Connector {
             return this.options.csrfToken;
         } else if (typeof document !== 'undefined' && (selector = document.querySelector('meta[name="csrf-token"]'))) {
             return selector.getAttribute('content');
-        } else if (typeof document !== 'undefined' && typeof document.cookie !== 'undefined' && (cookie = readCookie('XSRF-TOKEN'))) {
+        } else if (
+            typeof document !== 'undefined' &&
+            typeof document.cookie !== 'undefined' &&
+            (cookie = readCookie('XSRF-TOKEN'))
+        ) {
             return cookie;
         }
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -11,6 +11,7 @@ export abstract class Connector {
         authEndpoint: '/broadcasting/auth',
         broadcaster: 'pusher',
         csrfToken: null,
+        csrfCookie: 'X-CSRF-TOKEN',
         host: null,
         key: null,
         namespace: 'App.Events',
@@ -36,7 +37,7 @@ export abstract class Connector {
         this.options = Object.assign(this._defaultOptions, options);
 
         if (this.csrfToken()) {
-            this.options.auth.headers['X-CSRF-TOKEN'] = this.csrfToken();
+            this.options.auth.headers[this.options.csrfCookie] = this.csrfToken();
         }
 
         return options;
@@ -65,6 +66,7 @@ export abstract class Connector {
             typeof document.cookie !== 'undefined' &&
             (cookie = readCookie('XSRF-TOKEN'))
         ) {
+            this.options.csrfCookie = 'X-XSRF-TOKEN';
             return cookie;
         }
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -47,6 +47,12 @@ export abstract class Connector {
      */
     protected csrfToken(): string {
         let selector;
+        let cookie;
+
+        const readCookie = function(name) {
+          var match = document.cookie.match(new RegExp('(^|;\\s*)(' + name + ')=([^;]*)'));
+          return (match ? decodeURIComponent(match[3]) : null);
+        },
 
         if (typeof window !== 'undefined' && window['Laravel'] && window['Laravel'].csrfToken) {
             return window['Laravel'].csrfToken;
@@ -54,6 +60,8 @@ export abstract class Connector {
             return this.options.csrfToken;
         } else if (typeof document !== 'undefined' && (selector = document.querySelector('meta[name="csrf-token"]'))) {
             return selector.getAttribute('content');
+        } else if (typeof document !== 'undefined' && typeof document.cookie !== 'undefined' && (cookie = readCookie('XSRF-TOKEN'))) {
+            return cookie;
         }
 
         return null;


### PR DESCRIPTION
The Laravel skeleton was recently updated to stop explicitly setting the CSRF token on the axios client, as it can automatically get it from the XSRF-TOKEN Laravel adds by default. This PR introduces the same behavior on Echo.