### PR TITLE
Use jQuery.ajaxFilter instead of jQuery.ajaxSetup

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -142,12 +142,10 @@ export default class Echo {
      */
     registerjQueryAjaxSetup(): void {
         if (typeof jQuery.ajax != 'undefined') {
-            jQuery.ajaxSetup({
-                beforeSend: xhr => {
-                    if (this.socketId()) {
-                        xhr.setRequestHeader('X-Socket-Id', this.socketId());
-                    }
-                },
+            jQuery.ajaxPrefilter((options, originalOptions, xhr) => {
+                if (this.socketId()) {
+                    xhr.setRequestHeader('X-Socket-Id', this.socketId());
+                }
             });
         }
     }

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -138,7 +138,7 @@ export default class Echo {
     }
 
     /**
-     * Register jQuery AjaxSetup to add the X-Socket-ID header.
+     * Register jQuery AjaxPrefilter to add the X-Socket-ID header.
      */
     registerjQueryAjaxSetup(): void {
         if (typeof jQuery.ajax != 'undefined') {


### PR DESCRIPTION
`jQuery.ajaxSetup` will be easily get overridden when we are configuring `jQuery.ajax`, it is better to use `jQuery.ajaxPrefilter` which is like a middleware. same as `axios`.

Currently it is like this:
```js
$.ajaxSetup({
  beforeSend (xhr) {
    // We are adding socketId header here
  }
});

$.ajax({
  beforeSend (xhr) {
    // I want to do something else here, but the socketId header will be removed
  }
});
```
It should be like this: 
```js
$.ajaxPrefilter(function (options, originalOptions, xhr) {
  // We are adding socketId header here
});

$.ajax({
  beforeSend (xhr) {
    // I want to do something else here, the socketId will NOT be removed
    // I can also mange socketId header here (edit, remove, etc)
  }
});
```

There will be no breaking change. This PR will cause users to have more control over their AJAX requests and they won't need to add socketId header each time they use `beforeSend` AJAX option.