### PR TITLE
Change check for 'querySelector' method for browser compatibility

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -54,7 +54,7 @@ export abstract class Connector {
             return this.options.csrfToken;
         } else if (
             typeof document !== 'undefined' &&
-            document.hasOwnProperty('querySelector') &&
+            typeof document.querySelector === 'function' &&
             (selector = document.querySelector('meta[name="csrf-token"]'))
         ) {
             return selector.getAttribute('content');


### PR DESCRIPTION
```javascript
document.hasOwnProperty('querySelector')
```

The above conditions returns `false` in:
- Chrome 73.0.3683.103
- Firefox 67.0

:warning:  **I currently do not have the ability to test this change in React Native.**

Fixes https://github.com/laravel/echo/issues/252
