### PR TITLE
Added support for the "channelPrefix" option to Echo

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -36,7 +36,7 @@ export class PusherChannel extends Channel {
     constructor(pusher: any, name: any, options: any) {
         super();
 
-        this.name = name;
+        this.name = (options.channelPrefix || '') + name;
         this.pusher = pusher;
         this.options = options;
         this.eventFormatter = new EventFormatter(this.options.namespace);

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -36,7 +36,7 @@ export class SocketIoChannel extends Channel {
     constructor(socket: any, name: string, options: any) {
         super();
 
-        this.name = name;
+        this.name = (options.channelPrefix || '') + name;
         this.socket = socket;
         this.options = options;
         this.eventFormatter = new EventFormatter(this.options.namespace);


### PR DESCRIPTION
By default, Laravel will add a prefix to the redis database: 

config/database.php
```
    'redis' => [

        ...

        'options' => [
            'cluster' => env('REDIS_CLUSTER', 'redis'),
            'prefix' => env('REDIS_PREFIX', Str::slug(env('APP_NAME', 'laravel'), '_').'_database_'),
        ],

        ...
    ],
```

To compensate for this, you would have to add this prefix to all your Echo channels in your JS code like this (where "chatroom" is the channel being broadcasted to in the Laravel Event):
```
Echo.channel(`laravel_database_chatroom`)
    .listen('MyEvent', event => {
        ...
    })
```

This feels unnecessary and it looks silly, with my fix you will be able to provide a global channel prefix (just like the one provided to Redis) like so:
```
window.Echo = new Echo({
    broadcaster: 'socket.io',
    host: window.location.hostname + ':6001',
    channelPrefix: 'laravel_database_'
});

```

You might ask: why not just disable the Redis prefix?
To which the answer is obvious: those who use Redis for caching and/or queues for multiple apps on one Redis connection will be very happy with an app-specific prefix.