### PR TITLE
Header keys update

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -106,8 +106,8 @@ export default class Echo {
     }
 
     /**
-     * Register 3rd party request interceptiors. These are used to automatically
-     * send a connections socket id to a Laravel app with a X-Socket-Id header.
+     * Register 3rd party request interceptors. These are used to automatically
+     * send a connections socket id to a Laravel app with a X-Socket-ID header.
      */
     registerInterceptors(): void {
         if (typeof Vue === 'function' && Vue.http) {

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -106,8 +106,7 @@ export default class Echo {
     }
 
     /**
-     * Register 3rd party request interceptors. These are used to automatically
-     * send a connections socket id to a Laravel app with a X-Socket-ID header.
+     * Register third party request interceptors.
      */
     registerInterceptors(): void {
         if (typeof Vue === 'function' && Vue.http) {

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -142,7 +142,7 @@ export default class Echo {
     registerAxiosRequestInterceptor(): any {
         axios.interceptors.request.use((config) => {
             if (this.socketId()) {
-                config.headers['X-Socket-Id'] = this.socketId();
+                config.headers['X-Socket-ID'] = this.socketId();
             }
 
             return config;
@@ -156,7 +156,7 @@ export default class Echo {
         if (typeof jQuery.ajax != 'undefined') {
             jQuery.ajaxPrefilter((options, originalOptions, xhr) => {
                 if (this.socketId()) {
-                    xhr.setRequestHeader('X-Socket-Id', this.socketId());
+                    xhr.setRequestHeader('X-Socket-ID', this.socketId());
                 }
             });
         }


### PR DESCRIPTION
Currently troubleshooting an issue that I thought this may be the cause of, doesn't look like it is but I wanted to do a PR to be sure no one else goes down the same rabbit hole in the future. 

I had thought the headers being mis-capitalized was causing the `toOthers` method on the broadcasted event to not be able to locate the Socket ID. However after updating I'm still having that issue. 

Alternatively the header that Laravel is looking for in the BroadcastManager to `X-Socket-Id` and Vue updated here since these header keys get normalized anyhow. 