### PR TITLE
IE11 fix for dist/echo.js not being transpiled to ES5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,21 +28,25 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-decorators": "^7.8.3",
+    "@babel/plugin-proposal-export-namespace-from": "^7.8.3",
+    "@babel/plugin-proposal-function-sent": "^7.8.3",
+    "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+    "@babel/plugin-proposal-throw-expressions": "^7.8.3",
+    "@babel/plugin-transform-object-assign": "^7.8.3",
+    "@babel/preset-env": "^7.9.6",
+    "@rollup/plugin-babel": "^5.0.0",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.5",
-    "babel-plugin-transform-object-assign": "^6.22.0",
-    "babel-preset-es2015-rollup": "^3.0.0",
-    "babel-preset-stage-2": "^6.24.1",
     "jest": "^24.9.0",
-    "rollup": "^1.21.2",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-typescript": "^1.0.1",
+    "rollup": "^2.10.2",
+    "rollup-plugin-typescript2": "^0.27.1",
     "standard-version": "^7.0.0",
     "ts-jest": "^24.1.0",
     "tslib": "^1.10.0",
     "typescript": "^3.6.3"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,5 @@
-import typescript from 'rollup-plugin-typescript';
-import babel from 'rollup-plugin-babel';
+import babel from '@rollup/plugin-babel';
+import typescript from 'rollup-plugin-typescript2';
 
 export default {
     input: './src/echo.ts',
@@ -11,9 +11,18 @@ export default {
     plugins: [
         typescript(),
         babel({
+            babelHelpers: 'bundled',
             exclude: 'node_modules/**',
-            presets: ['es2015-rollup', 'stage-2'],
-            plugins: ['transform-object-assign'],
+            extensions: ['.ts'],
+            presets: ['@babel/preset-env'],
+            plugins: [
+                ['@babel/plugin-proposal-decorators', { legacy: true }],
+                '@babel/plugin-proposal-function-sent',
+                '@babel/plugin-proposal-export-namespace-from',
+                '@babel/plugin-proposal-numeric-separator',
+                '@babel/plugin-proposal-throw-expressions',
+                '@babel/plugin-transform-object-assign',
+            ],
         }),
     ],
 };


### PR DESCRIPTION
This covers https://github.com/laravel/echo/issues/266 to fix Laravel Echo no longer working in IE11 and other browsers that don't support native ES6.

### TLDR Fix

Add `rollup.config.js` option `extensions: ['.ts']` to explicitly whitelist the Babel plugin to handle the .ts -> ES6 transformed file.

### Should a package-lock.json be added?

Rollup was skipping plugin step `babel()` so the resulting distribution was in ES6 syntax rather than ES5.

Sometime after Laravel Echo v1.6.1 ( https://github.com/laravel/echo/commit/1cbd05381f584b4bbf161b1eed6e16753d6e6ba1 ) was tagged on Oct 1, 2019, an NPM _child_ dependency introduced a breaking change to the Rollup plugin for Babel. The step was being silently skipped so the v1.7.0-tagged dist/echo.js now being imported by Laravel apps was the plain Typescript -> ES6 transpile.

```
git reset 1cbd05381f584b4bbf161b1eed6e16753d6e6ba1
git clean -fd
rm -rf node_modules/
npm install
```

^ Using the 1.6.1 release commit, `npm run build` today generates a ES6 file, not ES5. Some nested  package.json dependency (one of over 600 packages) made a change but I still haven't figured out which. Reverting to an earlier `rollup-plugin-babel` version, still only ES6 is generated by `npm run build`.

I'd **strongly suggest introducing a package-lock.json** to prevent this from happening again.

### Why I had to update most NPM dev dependencies

1. NPM package `rollup-plugin-babel` won't allow defining that Rollup plugin option `extensions: ['.ts']`. Attempting it generates error "Plugin/Preset files are not allowed to export objects, only functions." This is caused by the old Babel 6 plugin ecosystem being used.
2. Bumping to Babel 7 requires changing the `rollup.config.js` plugin setup.
   * Preset `es2015-rollup` is replaced `@babel/preset-env` to target ES5
   * Preset `stage-2` is replaced by a handful of individual `@babel/plugin-` packages, as suggested by https://www.npmjs.com/package/@babel/preset-stage-2
3. To make this more complicated, Rollup has also changed NPM package namespacing similar to Babel. So I had to update `rollup` and change to the `@rollup/plugin-*` packages.
   * that requires bumping Echo dev environments to at least Node 10
4. However instead of upgrading `rollup-plugin-typescript` to `@rollup/plugin-typescript`, I had to replace it with fork `rollup-plugin-typescript2`.
   * `@rollup/plugin-typescript` won't transpile echo.ts to ES6 as it generates an error parsing Typescript despite the `tsconfig.json` and `typings/index.d.ts` configurations.
   * There is no upgrade path documented and Echo meets minimum requirements so I don't know what is happening. https://github.com/rollup/plugins/tree/master/packages/typescript

I need a drink.