### PR TITLE
Enable esModuleInterop in typescript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "sourceMap": false,
         "target": "es6",
         "isolatedModules": false,
+        "esModuleInterop": true,
         "typeRoots": [
             "node_modules/@types"
         ],


### PR DESCRIPTION
I was trying to write some tests for laravel-echo when I came across issues regarding import.

Steps to reproduce:

```
npm i socket.io-client @types/socket.io-client --save-dev
```

Then create `tests/socket-io.test.ts`

```ts
import Echo from "../src/echo";
import SocketIO from "socket.io-client";

describe("SocketIO", () => {
    test("use Echo with Socket.IO", () => {
        const echo = new Echo({
            broadcaster: "socket.io",
            client: SocketIO,
        });
    });
});
```

Run `npm test` and you should have the following error:

<img width="1051" alt="Screen Shot 2020-07-22 at 12 15 49" src="https://user-images.githubusercontent.com/356978/88133638-237d1180-cc15-11ea-8aa7-1053b548bddf.png">

Also, when you run `npm test`, jest is complaining about the config:

```
ts-jest[config] (WARN) TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
message TS151001: If you have issues related to imports, you should consider setting `esModuleInterop` to `true` in your TypeScript configuration file (usually `tsconfig.json`). See https://blogs.msdn.microsoft.com/typescript/2018/01/31/announcing-typescript-2-7/#easier-ecmascript-module-interoperability for more information.
```

This patch fixes both the warning and import issues.

I ran `shasum ./dist/echo.js ./dist/echo.common.js ./dist/echo.iife.js` after `npm run build` with and without the patched config and files are still identical, it should not have any side effect AFAIK.