### PR TITLE
Run build on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,3 +20,6 @@ jobs:
 
       - name: Execute tests
         run: npm test
+
+      - name: Run build
+        run: npm run build


### PR DESCRIPTION
Are there any reasons that only tests are run on the CI?
They are very limited and I think `npm run build` should be run as well to ensure that it is at least compiling properly.