### PR TITLE
Add ESLint with Typescript support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+    root: true,
+    env: {
+        browser: true,
+        jest: true,
+        node: true,
+    },
+    parser: "@typescript-eslint/parser",
+    plugins: ["@typescript-eslint"],
+    extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+    rules: {
+        "@typescript-eslint/ban-types": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "prefer-const": "off",
+    },
+};

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,5 +18,8 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: ESLint
+        run: npm run lint
+
       - name: Execute tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "build": "npm run compile && npm run declarations",
         "compile": "./node_modules/.bin/rollup -c",
         "declarations": "./node_modules/.bin/tsc --emitDeclarationOnly",
+        "lint": "eslint --ext .js,.ts ./src ./tests",
         "prepublish": "npm run build",
         "release": "npm run test && standard-version && git push --follow-tags && npm publish",
         "test": "jest"
@@ -38,6 +39,9 @@
         "@rollup/plugin-babel": "^5.0.0",
         "@types/jest": "^24.0.18",
         "@types/node": "^12.7.5",
+        "@typescript-eslint/eslint-plugin": "^3.7.0",
+        "@typescript-eslint/parser": "^3.7.0",
+        "eslint": "^7.5.0",
         "jest": "^24.9.0",
         "rollup": "^2.10.2",
         "rollup-plugin-typescript2": "^0.27.1",


### PR DESCRIPTION
This PR adds ESLint with Typescript support, and also runs it on CI.

Usage:

```bash
npm run lint

# ignore warnings
npm run lint -- --quiet 
```

Config is using only the recommended rules:

- `eslint:recommended`
- `@typescript-eslint/recommended`

I disabled 3 rules that currently trigger errors:

- `@typescript-eslint/ban-types`
- `@typescript-eslint/no-explicit-any`
- `prefer-const`

If this PR gets merged, I will then make separate PRs to fix those errors, it should be easier to review that way.