### PR TITLE
[ESLint] Fix prefer-const

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,5 @@ module.exports = {
     rules: {
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "prefer-const": "off",
     },
 };

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -91,7 +91,7 @@ export class SocketIoChannel extends Channel {
      * Bind the channel's socket to an event and store the callback.
      */
     on(event: string, callback: Function): void {
-        let listener = (channel, data) => {
+        const listener = (channel, data) => {
             if (this.name == channel) {
                 callback(data);
             }

--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -95,7 +95,7 @@ export class PusherConnector extends Connector {
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [name, 'private-' + name, 'presence-' + name];
+        const channels = [name, 'private-' + name, 'presence-' + name];
 
         channels.forEach((name: string, index: number) => {
             this.leaveChannel(name);

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -19,7 +19,7 @@ export class SocketIoConnector extends Connector {
      * Create a fresh Socket.io connection.
      */
     connect(): void {
-        let io = this.getSocketIO();
+        const io = this.getSocketIO();
 
         this.socket = io(this.options.host, this.options);
 
@@ -89,7 +89,7 @@ export class SocketIoConnector extends Connector {
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [name, 'private-' + name, 'presence-' + name];
+        const channels = [name, 'private-' + name, 'presence-' + name];
 
         channels.forEach((name) => {
             this.leaveChannel(name);

--- a/tests/util/event-formatter.test.ts
+++ b/tests/util/event-formatter.test.ts
@@ -8,39 +8,39 @@ describe('EventFormatter', () => {
     });
 
     test('prepends an event with a namespace and replaces dot separators with backslashes', () => {
-        let formatted = eventFormatter.format('Users.UserCreated');
+        const formatted = eventFormatter.format('Users.UserCreated');
 
         expect(formatted).toBe('App\\Events\\Users\\UserCreated');
     });
 
     test('does not prepend a namespace when an event starts with a dot', () => {
-        let formatted = eventFormatter.format('.App\\Users\\UserCreated');
+        const formatted = eventFormatter.format('.App\\Users\\UserCreated');
 
         expect(formatted).toBe('App\\Users\\UserCreated');
     });
 
     test('does not prepend a namespace when an event starts with a backslash', () => {
-        let formatted = eventFormatter.format('\\App\\Users\\UserCreated');
+        const formatted = eventFormatter.format('\\App\\Users\\UserCreated');
 
         expect(formatted).toBe('App\\Users\\UserCreated');
     });
 
     test('does not replace dot separators when the event starts with a dot', () => {
-        let formatted = eventFormatter.format('.users.created');
+        const formatted = eventFormatter.format('.users.created');
 
         expect(formatted).toBe('users.created');
     });
 
     test('does not replace dot separators when the event starts with a backslash', () => {
-        let formatted = eventFormatter.format('\\users.created');
+        const formatted = eventFormatter.format('\\users.created');
 
         expect(formatted).toBe('users.created');
     });
 
     test('does not prepend a namespace when none is set', () => {
-        let eventFormatter = new EventFormatter(false);
+        const eventFormatter = new EventFormatter(false);
 
-        let formatted = eventFormatter.format('Users.UserCreated');
+        const formatted = eventFormatter.format('Users.UserCreated');
 
         expect(formatted).toBe('Users\\UserCreated');
     });


### PR DESCRIPTION
Fix for [prefer-const](https://eslint.org/docs/rules/prefer-const) errors on ESLint:

```bash
❯ npm run lint -- --quiet

/Users/manu/Code/echo/src/channel/socketio-channel.ts
  94:13  error  'listener' is never reassigned. Use 'const' instead  prefer-const

/Users/manu/Code/echo/src/connector/pusher-connector.ts
  98:13  error  'channels' is never reassigned. Use 'const' instead  prefer-const

/Users/manu/Code/echo/src/connector/socketio-connector.ts
  22:13  error  'io' is never reassigned. Use 'const' instead        prefer-const
  92:13  error  'channels' is never reassigned. Use 'const' instead  prefer-const

/Users/manu/Code/echo/tests/util/event-formatter.test.ts
  11:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const
  17:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const
  23:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const
  29:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const
  35:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const
  41:13  error  'eventFormatter' is never reassigned. Use 'const' instead  prefer-const
  43:13  error  'formatted' is never reassigned. Use 'const' instead       prefer-const

✖ 11 problems (11 errors, 0 warnings)
  11 errors and 0 warnings potentially fixable with the `--fix` option.
```

Files from build are still identical after patch:

```bash
❯ shasum ./dist/echo.js ./dist/echo.common.js ./dist/echo.iife.js
f4353fea89a20400d4420debd14cb93311198496  ./dist/echo.js
de8f0de5996df5a1add580a9b131466b547ba952  ./dist/echo.common.js
03f7469cff0f7e895fbd097064bbb1cefdf7393d  ./dist/echo.iife.js
```