### PR TITLE
Register subscription succeeded callbacks

### DIFF
--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -39,6 +39,11 @@ export abstract class Channel {
     }
 
     /**
+     * Register a callback to be called anytime a subscription succeeds.
+     */
+    abstract subscriptionSucceeded(callback: Function): Channel;
+
+    /**
      * Register a callback to be called anytime an error occurs.
      */
     abstract error(callback: Function): Channel;

--- a/src/channel/null-channel.ts
+++ b/src/channel/null-channel.ts
@@ -33,6 +33,13 @@ export class NullChannel extends Channel {
     }
 
     /**
+     * Register a callback to be called anytime a subscription succeeds.
+     */
+    subscriptionSucceeded(callback: Function): NullChannel {
+        return this;
+    }
+
+    /**
      * Register a callback to be called anytime an error occurs.
      */
     error(callback: Function): NullChannel {

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -77,6 +77,17 @@ export class PusherChannel extends Channel {
     }
 
     /**
+     * Register a callback to be called anytime a subscription succeeds.
+     */
+    subscriptionSucceeded(callback: Function): PusherChannel {
+        this.on('pusher:subscription_succeeded', () => {
+            callback()
+        });
+
+        return this;
+    }
+
+    /**
      * Register a callback to be called anytime a subscription error occurs.
      */
     error(callback: Function): PusherChannel {

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -81,7 +81,7 @@ export class PusherChannel extends Channel {
      */
     subscriptionSucceeded(callback: Function): PusherChannel {
         this.on('pusher:subscription_succeeded', () => {
-            callback()
+            callback();
         });
 
         return this;

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -91,7 +91,7 @@ export class SocketIoChannel extends Channel {
      * Register a callback to be called anytime a subscription succeeds.
      */
     subscriptionSucceeded(callback: Function): SocketIoChannel {
-        this.on('connection', (socket) => {
+        this.on('connect', (socket) => {
             callback(socket);
         })
 

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -88,6 +88,17 @@ export class SocketIoChannel extends Channel {
     }
 
     /**
+     * Register a callback to be called anytime a subscription succeeds.
+     */
+    subscriptionSucceeded(callback: Function): SocketIoChannel {
+        this.on('connection', (socket) => {
+            callback(socket);
+        })
+
+        return this;
+    }
+
+    /**
      * Register a callback to be called anytime an error occurs.
      */
     error(callback: Function): SocketIoChannel {

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -93,7 +93,7 @@ export class SocketIoChannel extends Channel {
     subscriptionSucceeded(callback: Function): SocketIoChannel {
         this.on('connect', (socket) => {
             callback(socket);
-        })
+        });
 
         return this;
     }


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a `subscriptionSucceeded` method to all channels, allowing developers to register a callback for `pusher:subscription_succeeded`(pusher) and `connect` (socket.io) events

The NullChannel returns the channel instance without registering a callback.
