### PR TITLE
Add optional callback argument to stopListening()

### DIFF
--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -29,13 +29,13 @@ export abstract class Channel {
     /**
      * Stop listening to an event on the channel instance.
      */
-    abstract stopListening(event: string): Channel;
+    abstract stopListening(event: string, callback?: Function): Channel;
 
     /**
      * Stop listening for a whisper event on the channel instance.
      */
-    stopListeningForWhisper(event: string): Channel {
-        return this.stopListening('.client-' + event);
+    stopListeningForWhisper(event: string, callback?: Function): Channel {
+        return this.stopListening('.client-' + event, callback);
     }
 
     /**

--- a/src/channel/null-channel.ts
+++ b/src/channel/null-channel.ts
@@ -28,7 +28,7 @@ export class NullChannel extends Channel {
     /**
      * Stop listening for an event on the channel instance.
      */
-    stopListening(event: string): NullChannel {
+    stopListening(event: string, callback?: Function): NullChannel {
         return this;
     }
 

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -70,8 +70,12 @@ export class PusherChannel extends Channel {
     /**
      * Stop listening for an event on the channel instance.
      */
-    stopListening(event: string): PusherChannel {
-        this.subscription.unbind(this.eventFormatter.format(event));
+    stopListening(event: string, callback?: Function): PusherChannel {
+        if (callback) {
+            this.subscription.unbind(this.eventFormatter.format(event), callback);
+        } else {
+            this.subscription.unbind(this.eventFormatter.format(event));
+        }
 
         return this;
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -79,10 +79,18 @@ export class SocketIoChannel extends Channel {
     /**
      * Stop listening for an event on the channel instance.
      */
-    stopListening(event: string): SocketIoChannel {
+    stopListening(event: string, callback?: Function): SocketIoChannel {
         const name = this.eventFormatter.format(event);
-        this.socket.removeListener(name);
-        delete this.events[name];
+
+        if (callback && this.events[name]) {
+            this.socket.removeListener(name, callback);
+            this.events[name] = this.events[name].filter((cb) => cb !== callback);
+        }
+
+        if (!callback || (this.events[name] && this.events[name].length === 0)) {
+            this.socket.removeListener(name);
+            delete this.events[name];
+        }
 
         return this;
     }


### PR DESCRIPTION
This makes it possible to unregister a single callback for an event, without unregistering all other callbacks for that event on that channel. This is very helpful for example when using react hooks, where you need to stop listening as the component is unmounted. Here's an example component using this new functionality:

    const MyEventMessagesList = () => {
        const [messages, setMessages] = useState([]);

        useEffect(() => {
            const pushMessage = message => setMessages(prev => [...prev, message]);
            const channel = Echo.private("my.channel")
                .listen("MyEvent", pushMessage);

            // It used to be cumbersome to unregister a single callback
            // for an event, but now you can just do this:
            return () => channel.stopListening("MyEvent", pushMessage);
        }, [setMessages]);

        return (
            <ul>
                {messages.map((m, i) =>
                    <li key={i}>{m}</li>
                )}
            </ul>
        )
    }

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
