### PR TITLE
Add optional callback argument to stopListening()

### DIFF
--- a/src/channel/channel.ts
+++ b/src/channel/channel.ts
@@ -29,13 +29,13 @@ export abstract class Channel {
     /**
      * Stop listening to an event on the channel instance.
      */
-    abstract stopListening(event: string): Channel;
+    abstract stopListening(event: string, callback?: Function): Channel;
 
     /**
      * Stop listening for a whisper event on the channel instance.
      */
-    stopListeningForWhisper(event: string): Channel {
-        return this.stopListening('.client-' + event);
+    stopListeningForWhisper(event: string, callback?: Function): Channel {
+        return this.stopListening('.client-' + event, callback);
     }
 
     /**

--- a/src/channel/null-channel.ts
+++ b/src/channel/null-channel.ts
@@ -28,7 +28,7 @@ export class NullChannel extends Channel {
     /**
      * Stop listening for an event on the channel instance.
      */
-    stopListening(event: string): NullChannel {
+    stopListening(event: string, callback?: Function): NullChannel {
         return this;
     }
 

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -70,8 +70,12 @@ export class PusherChannel extends Channel {
     /**
      * Stop listening for an event on the channel instance.
      */
-    stopListening(event: string): PusherChannel {
-        this.subscription.unbind(this.eventFormatter.format(event));
+    stopListening(event: string, callback?: Function): PusherChannel {
+        if (callback) {
+            this.subscription.unbind(this.eventFormatter.format(event), callback);
+        } else {
+            this.subscription.unbind(this.eventFormatter.format(event));
+        }
 
         return this;
     }

--- a/src/channel/socketio-channel.ts
+++ b/src/channel/socketio-channel.ts
@@ -42,7 +42,6 @@ export class SocketIoChannel extends Channel {
         this.eventFormatter = new EventFormatter(this.options.namespace);
 
         this.subscribe();
-        this.configureReconnector();
     }
 
     /**
@@ -117,18 +116,6 @@ export class SocketIoChannel extends Channel {
 
         this.socket.on(event, listener);
         this.bind(event, listener);
-    }
-
-    /**
-     * Attach a 'reconnect' listener and bind the event.
-     */
-    configureReconnector(): void {
-        const listener = () => {
-            this.subscribe();
-        };
-
-        this.socket.on('reconnect', listener);
-        this.bind('reconnect', listener);
     }
 
     /**

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -13,7 +13,7 @@ export class SocketIoConnector extends Connector {
     /**
      * All of the subscribed channel names.
      */
-    channels: any = {};
+    channels: { [name: string]: SocketIoChannel } = {};
 
     /**
      * Create a fresh Socket.io connection.
@@ -22,6 +22,12 @@ export class SocketIoConnector extends Connector {
         let io = this.getSocketIO();
 
         this.socket = io(this.options.host, this.options);
+
+        this.socket.on('reconnect', () => {
+            Object.values(this.channels).forEach((channel) => {
+                channel.subscribe();
+            });
+        });
 
         return this.socket;
     }
@@ -67,7 +73,7 @@ export class SocketIoConnector extends Connector {
             this.channels['private-' + name] = new SocketIoPrivateChannel(this.socket, 'private-' + name, this.options);
         }
 
-        return this.channels['private-' + name];
+        return this.channels['private-' + name] as SocketIoPrivateChannel;
     }
 
     /**
@@ -82,7 +88,7 @@ export class SocketIoConnector extends Connector {
             );
         }
 
-        return this.channels['presence-' + name];
+        return this.channels['presence-' + name] as SocketIoPresenceChannel;
     }
 
     /**

--- a/tests/channel/socketio-channel.test.ts
+++ b/tests/channel/socketio-channel.test.ts
@@ -1,0 +1,83 @@
+import { SocketIoChannel } from '../../src/channel';
+
+describe('SocketIoChannel', () => {
+    let channel;
+    let socket;
+
+    beforeEach(() => {
+        const channelName = 'some.channel';
+        let listeners = [];
+        socket = {
+            emit: (event, data) => listeners.filter(([e]) => e === event).forEach(([, fn]) => fn(channelName, data)),
+            on: (event, fn) => listeners.push([event, fn]),
+            removeListener: (event, fn) => {
+                listeners = listeners.filter(([e, f]) => (!fn ? e !== event : e !== event || f !== fn));
+            },
+        };
+
+        channel = new SocketIoChannel(socket, channelName, {
+            namespace: false,
+        });
+    });
+
+    test('triggers all listeners for an event', () => {
+        const l1 = jest.fn();
+        const l2 = jest.fn();
+        const l3 = jest.fn();
+        channel.listen('MyEvent', l1);
+        channel.listen('MyEvent', l2);
+        channel.listen('MyOtherEvent', l3);
+
+        socket.emit('MyEvent', {});
+
+        expect(l1).toBeCalled();
+        expect(l2).toBeCalled();
+        expect(l3).not.toBeCalled();
+
+        socket.emit('MyOtherEvent', {});
+
+        expect(l3).toBeCalled();
+    });
+
+    test('can remove a listener for an event', () => {
+        const l1 = jest.fn();
+        const l2 = jest.fn();
+        const l3 = jest.fn();
+        channel.listen('MyEvent', l1);
+        channel.listen('MyEvent', l2);
+        channel.listen('MyOtherEvent', l3);
+
+        channel.stopListening('MyEvent', l1);
+
+        socket.emit('MyEvent', {});
+
+        expect(l1).not.toBeCalled();
+        expect(l2).toBeCalled();
+        expect(l3).not.toBeCalled();
+
+        socket.emit('MyOtherEvent', {});
+
+        expect(l3).toBeCalled();
+    });
+
+    test('can remove all listeners for an event', () => {
+        const l1 = jest.fn();
+        const l2 = jest.fn();
+        const l3 = jest.fn();
+        channel.listen('MyEvent', l1);
+        channel.listen('MyEvent', l2);
+        channel.listen('MyOtherEvent', l3);
+
+        channel.stopListening('MyEvent');
+
+        socket.emit('MyEvent', {});
+
+        expect(l1).not.toBeCalled();
+        expect(l2).not.toBeCalled();
+        expect(l3).not.toBeCalled();
+
+        socket.emit('MyOtherEvent', {});
+
+        expect(l3).toBeCalled();
+    });
+});


### PR DESCRIPTION
(Second attempt, see #291)

This makes it possible to unregister a single callback for an event, without unregistering all other callbacks for that event on that channel. This is very helpful for example when using react hooks, where you need to stop listening as the component is unmounted. Here's an example React component using this new functionality:

    const MyEventMessagesList = () => {
        const [messages, setMessages] = useState([]);

        useEffect(() => {
            const pushMessage = message => setMessages(prev => [...prev, message]);
            const channel = Echo.private("my.channel")
                .listen("MyEvent", pushMessage);

            // It used to be impossible to unregister a single callback
            // for an event, but now you can do this:
            return () => channel.stopListening("MyEvent", pushMessage); // Unregister only the pushMessage callback for this event
        }, [setMessages]);

        return (
            <ul>
                {messages.map((m, i) =>
                    <li key={i}>{m}</li>
                )}
            </ul>
        )
    }

Prior to this PR it was not possible to unregister a callback for an event. This is because the callback was wrapped inside the channel class to filter out events from other channels (see https://github.com/laravel/echo/blob/8bd9a2b2e7670b376f742660f4b2d47614361795/src/channel/socketio-channel.ts#L112). It was therefore impossible to map the callback the user provided when calling `channel.listen()` to the callback which was actually registered with the socket. This in turn meant it was not possible to selectively remove just that callback from the socket.

I have solved this by registering just one callback per event, which in turn iterates over a list of user-provided callbacks. The list of user-provided callbacks can therefore be modified, and a single user-provided callback can be selectively unregistered.

I've added a few tests for the socket.io channel because the new code is a bit more complex than it used to be.

I have tried to not introduce any backwards incompatible changes here. That's why there's still an `channel.on()` function, despite it just proxying to the new `channel.bindChannelEvent`. All new functions has been marked as `protected` to discourage consumers of this package to call them directly. New properties have been marked as private.

This PR also fixes a bug in the socket.io channel, where calling `stopListening(event)` would stop the socket from listening to that event for all channels, not just the current one. If you look at this line: https://github.com/laravel/echo/blob/8bd9a2b2e7670b376f742660f4b2d47614361795/src/channel/socketio-channel.ts#L84 you'll see that all listeners are removed for that event on the underlying socket, not just the listeners specific to this channel (since all channels share the same socket). This PR solves that by always keeping track of which callbacks have been registered with the socket, and unregistering just those.