### PR TITLE
Add "interceptorUrls" option

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -111,9 +111,9 @@ export default class Echo {
     shouldApplySocketIdHeader(url: string): boolean {
         const origin = new URL(url).origin;
 
-        return this.socketId()
-            && (!('interceptorUrls' in this.options)
-            || this.options.interceptorUrls.includes(origin));
+        return (
+            this.socketId() && (!('interceptorUrls' in this.options) || this.options.interceptorUrls.includes(origin))
+        );
     }
 
     /**

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -106,6 +106,17 @@ export default class Echo {
     }
 
     /**
+     * Check if Socket ID header should be applied to a request.
+     */
+    shouldApplySocketIdHeader(url: string): boolean {
+        const origin = new URL(url).origin;
+
+        return this.socketId()
+            && (!('interceptorUrls' in this.options)
+            || this.options.interceptorUrls.includes(origin));
+    }
+
+    /**
      * Register 3rd party request interceptiors. These are used to automatically
      * send a connections socket id to a Laravel app with a X-Socket-Id header.
      */
@@ -128,7 +139,7 @@ export default class Echo {
      */
     registerVueRequestInterceptor(): void {
         Vue.http.interceptors.push((request, next) => {
-            if (this.socketId()) {
+            if (this.shouldApplySocketIdHeader(request.url)) {
                 request.headers.set('X-Socket-ID', this.socketId());
             }
 
@@ -141,7 +152,7 @@ export default class Echo {
      */
     registerAxiosRequestInterceptor(): void {
         axios.interceptors.request.use((config) => {
-            if (this.socketId()) {
+            if (this.shouldApplySocketIdHeader(config.url)) {
                 config.headers['X-Socket-Id'] = this.socketId();
             }
 
@@ -155,7 +166,7 @@ export default class Echo {
     registerjQueryAjaxSetup(): void {
         if (typeof jQuery.ajax != 'undefined') {
             jQuery.ajaxPrefilter((options, originalOptions, xhr) => {
-                if (this.socketId()) {
+                if (this.shouldApplySocketIdHeader(options.url)) {
                     xhr.setRequestHeader('X-Socket-Id', this.socketId());
                 }
             });


### PR DESCRIPTION
The interceptorUrls option would allow users to apply the X-Socker-Id header only on requests to certain URLs.  This is an alternative to disabling it entirely using withoutInterceptors, which I’m currently doing in a project to prevent CORS errors from some third party APIs which don’t allow the header.

Omitting the interceptorUrls option falls back to the original behavior of adding the X-Socket-Id header to all requests.  The withoutInterceptors option will override this option.

Example usage:

```
new Echo({
    interceptorUrls: ['https://wants-x-socket-headers.com']
    ...
});
```