### PR TITLE
Add listenToAll and stopListeningToAll

### DIFF
--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -85,15 +85,13 @@ export class PusherChannel extends Channel {
      */
     listenToAll(callback: Function): PusherChannel {
         this.subscription.bind_global((event, data) => {
-            if (event.startsWith('pusher:')){
+            if (event.startsWith('pusher:')) {
                 return;
             }
 
             let namespace = this.options.namespace.replace(/\./g, '\\');
 
-            let formattedEvent = event.startsWith(namespace)
-                ? event.substring(namespace.length + 1)
-                : '.' + event;
+            let formattedEvent = event.startsWith(namespace) ? event.substring(namespace.length + 1) : '.' + event;
 
             callback(formattedEvent, data);
         });

--- a/src/channel/pusher-channel.ts
+++ b/src/channel/pusher-channel.ts
@@ -81,6 +81,40 @@ export class PusherChannel extends Channel {
     }
 
     /**
+     * Listen for all events on the channel instance.
+     */
+    listenToAll(callback: Function): PusherChannel {
+        this.subscription.bind_global((event, data) => {
+            if (event.startsWith('pusher:')){
+                return;
+            }
+
+            let namespace = this.options.namespace.replace(/\./g, '\\');
+
+            let formattedEvent = event.startsWith(namespace)
+                ? event.substring(namespace.length + 1)
+                : '.' + event;
+
+            callback(formattedEvent, data);
+        });
+
+        return this;
+    }
+
+    /**
+     * Stop listening for all events on the channel instance.
+     */
+    stopListeningToAll(callback?: Function): PusherChannel {
+        if (callback) {
+            this.subscription.unbind_global(callback);
+        } else {
+            this.subscription.unbind_global();
+        }
+
+        return this;
+    }
+
+    /**
      * Register a callback to be called anytime a subscription succeeds.
      */
     subscribed(callback: Function): PusherChannel {


### PR DESCRIPTION
```js
Echo.channel('channel')
    .listenToAll((event, data) => {
        console.log(e);
    })
```

This will add a listener to all non pusher events (events that doesn't start with `pusher:`).

It'll remove the namespace from the event name, and adds a dot to the event name if it wasn't namespaced so people can expected the same format for event names as they'd use with `listen()`.