### PR TITLE
fix types in connector.ts

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -45,7 +45,7 @@ export abstract class Connector {
     /**
      * Extract the CSRF token from the page.
      */
-    protected csrfToken(): string {
+    protected csrfToken(): null | string {
         let selector;
 
         if (typeof window !== 'undefined' && window['Laravel'] && window['Laravel'].csrfToken) {


### PR DESCRIPTION
Return type of `csrfToken()` is a `string`, but it actually can return `null`. This PR adds `null` to possible return types to resolve typescript compiler error