### PR TITLE
[1.x] Fix IIFE build

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,9 +30,7 @@ export default [
     },
     {
         input: './src/index.iife.ts',
-        output: [
-            { file: './dist/echo.iife.js', format: 'iife', name: 'Echo' },
-        ],
+        output: [{ file: './dist/echo.iife.js', format: 'iife', name: 'Echo' }],
         plugins,
-    }
+    },
 ];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,28 +1,38 @@
 import babel from '@rollup/plugin-babel';
 import typescript from 'rollup-plugin-typescript2';
 
-export default {
-    input: './src/echo.ts',
-    output: [
-        { file: './dist/echo.js', format: 'esm' },
-        { file: './dist/echo.common.js', format: 'cjs' },
-        { file: './dist/echo.iife.js', format: 'iife', name: 'Echo' },
-    ],
-    plugins: [
-        typescript(),
-        babel({
-            babelHelpers: 'bundled',
-            exclude: 'node_modules/**',
-            extensions: ['.ts'],
-            presets: ['@babel/preset-env'],
-            plugins: [
-                ['@babel/plugin-proposal-decorators', { legacy: true }],
-                '@babel/plugin-proposal-function-sent',
-                '@babel/plugin-proposal-export-namespace-from',
-                '@babel/plugin-proposal-numeric-separator',
-                '@babel/plugin-proposal-throw-expressions',
-                '@babel/plugin-transform-object-assign',
-            ],
-        }),
-    ],
-};
+const plugins = [
+    typescript(),
+    babel({
+        babelHelpers: 'bundled',
+        exclude: 'node_modules/**',
+        extensions: ['.ts'],
+        presets: ['@babel/preset-env'],
+        plugins: [
+            ['@babel/plugin-proposal-decorators', { legacy: true }],
+            '@babel/plugin-proposal-function-sent',
+            '@babel/plugin-proposal-export-namespace-from',
+            '@babel/plugin-proposal-numeric-separator',
+            '@babel/plugin-proposal-throw-expressions',
+            '@babel/plugin-transform-object-assign',
+        ],
+    }),
+];
+
+export default [
+    {
+        input: './src/echo.ts',
+        output: [
+            { file: './dist/echo.js', format: 'esm' },
+            { file: './dist/echo.common.js', format: 'cjs' },
+        ],
+        plugins,
+    },
+    {
+        input: './src/index.iife.ts',
+        output: [
+            { file: './dist/echo.iife.js', format: 'iife', name: 'Echo' },
+        ],
+        plugins,
+    }
+];

--- a/src/index.iife.ts
+++ b/src/index.iife.ts
@@ -1,1 +1,1 @@
-export { default } from './echo'
+export { default } from './echo';

--- a/src/index.iife.ts
+++ b/src/index.iife.ts
@@ -1,0 +1,1 @@
+export { default } from './echo'


### PR DESCRIPTION
As reported in https://github.com/laravel/echo/issues/343, the IIFE functionality had a breaking change recently that saw the usage of `window.Echo` break. The manual fix was to start referencing `window.Echo.default`.

This break was caused by the additional exports from echo to improve the packages usage within Typescript packages, which I believe in theory is a good idea.

This PR introduces an additional build config for the IIFE version which allows us to _only_ export the Echo class, thus returning to the original `window.Echo` functionality for IIFE usage.