### PR TITLE
[1.x] Introduce root index for exporting

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import babel from '@rollup/plugin-babel';
 import typescript from 'rollup-plugin-typescript2';
 
 export default {
-    input: './src/echo.ts',
+    input: './src/index.ts',
     output: [
         { file: './dist/echo.js', format: 'esm' },
         { file: './dist/echo.common.js', format: 'cjs' },

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -162,8 +162,3 @@ export default class Echo {
         }
     }
 }
-
-/**
- * Export channel classes for TypeScript.
- */
-export { Channel, PresenceChannel };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,4 @@
+export { default } from './echo'
+export * from './channel';
+export * from './connector';
+export * from './util';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { default } from './echo'
+export { default } from './echo';
 export * from './channel';
 export * from './connector';
 export * from './util';


### PR DESCRIPTION
This PR introduces an index file in the root of the package to deal with exporting. This is common convention for packages and is how we seem to do things across the Laravel ecosystem.

This also pairs with https://github.com/laravel/echo/pull/344 where we introduce a dedicated index for IIFE builds and removes what seems like arbitrary exports from the `echo.ts` file, just to support TS - where is this is a dedicated place to export things for TS etc.