### PR TITLE
Bearer token support for User Authentication

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -15,6 +15,7 @@ export abstract class Connector {
         },
         broadcaster: 'pusher',
         csrfToken: null,
+        bearerToken: null,
         host: null,
         key: null,
         namespace: 'App.Events',
@@ -44,6 +45,9 @@ export abstract class Connector {
         if (token) {
             this.options.auth.headers['X-CSRF-TOKEN'] = token;
             this.options.userAuthentication.headers['X-CSRF-TOKEN'] = token;
+        } else if (this.options.bearerToken) {
+            this.options.auth.headers['Authorization'] = 'Bearer ' + this.options.bearerToken;
+            this.options.userAuthentication.headers['Authorization'] = 'Bearer ' + this.options.bearerToken;
         }
 
         return options;


### PR DESCRIPTION
## Context
* PR: [[9.x] User authentication for Pusher framework#42531](https://github.com/laravel/framework/pull/42531)
* `signin()` method: https://pusher.com/docs/channels/using_channels/user-authentication/#sign-in
* Complement of  https://github.com/laravel/echo/pull/340

## Breaking Changes
None.
