### PR TITLE
Bearer token support for User Authentication

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -15,6 +15,7 @@ export abstract class Connector {
         },
         broadcaster: 'pusher',
         csrfToken: null,
+        bearerToken: null,
         host: null,
         key: null,
         namespace: 'App.Events',
@@ -44,6 +45,10 @@ export abstract class Connector {
         if (token) {
             this.options.auth.headers['X-CSRF-TOKEN'] = token;
             this.options.userAuthentication.headers['X-CSRF-TOKEN'] = token;
+        }
+        if (this.options.bearerToken) {
+            this.options.auth.headers['Authorization'] = 'Bearer ' + this.options.bearerToken;
+            this.options.userAuthentication.headers['Authorization'] = 'Bearer ' + this.options.bearerToken;
         }
 
         return options;


### PR DESCRIPTION
This PR helps when you use tokens like in APIs

### Purpose
Pusher launched a feature that allows their users to enable authentication for connections, alongside the channel authorizations: https://pusher.com/docs/channels/using_channels/user-authentication/
It's a feature that will make sure that anyone connecting to the websockets should be an authenticated user within the app. 

### Example
**Before:**
```ts
{
        broadcaster: 'pusher',
        auth: {
            headers: {
                Authorization: "Bearer " + TOKEN_STRING
            },
        },
        userAuthentication: {
            headers: {
                Authorization: "Bearer " + TOKEN_STRING
            },
        },

        host: HOST,
        key: APP_KEY
    }
```
**After:**
```ts
{       
        broadcaster: 'pusher',
        bearerToken: TOKEN_STRING,
        host: HOST,
        key: APP_KEY
}
```

## Context
* PR: [9.x] User authentication for Pusher framework#42531
* `signin()` method: https://pusher.com/docs/channels/using_channels/user-authentication/#sign-in


Same as `CSRF-TOKEN`
https://github.com/laravel/echo/blob/d41094a794edb85e87ee11fd69328ddf5b7e4091/src/connector/connector.ts#L44-L47