### PR TITLE
Adds Turbo Interceptor to add X-Socket-Id header on Turbo requests

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -121,6 +121,10 @@ export default class Echo {
         if (typeof jQuery === 'function') {
             this.registerjQueryAjaxSetup();
         }
+
+        if (typeof Turbo === 'object') {
+            this.registerTurboRequestInterceptor();
+        }
     }
 
     /**
@@ -160,6 +164,15 @@ export default class Echo {
                 }
             });
         }
+    }
+
+    /**
+     * Register the Turbo Request interceptor to add the X-Socket-ID header.
+     */
+    registerTurboRequestInterceptor(): void {
+        document.addEventListener('turbo:before-fetch-request', (event: any) => {
+            event.detail.fetchOptions.headers['X-Socket-Id'] = this.socketId();
+        });
     }
 }
 

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,3 +3,4 @@ declare let io: any;
 declare let Vue: any;
 declare let axios: any;
 declare let jQuery: any;
+declare let Turbo: any;


### PR DESCRIPTION
### Added

- Adds a request interceptor to add the `X-Socket-Id` header to all Turbo requests by listening to the `turbo:before-fetch-request` event ([docs)](https://turbo.hotwired.dev/reference/events)