### PR TITLE
Also leave Pusher private encrypted channel

### DIFF
--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -102,7 +102,7 @@ export class PusherConnector extends Connector {
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [name, 'private-' + name, 'presence-' + name];
+        let channels = [name, 'private-' + name, 'private-encrypted-' + name, 'presence-' + name];
 
         channels.forEach((name: string, index: number) => {
             this.leaveChannel(name);


### PR DESCRIPTION
Added the 'private-encrypted-' prefix to channel names to be checked when leaving a Pusher channel. When you want to leave an encrypted channel now you have to prefix the name with 'encrypted-'. With this change you can pass the same name as joining the channel via Echo.encryptedPrivate.