### PR TITLE
Bearer token Authorization support

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -15,6 +15,7 @@ export abstract class Connector {
         },
         broadcaster: 'pusher',
         csrfToken: null,
+        bearerToken: null,
         host: null,
         key: null,
         namespace: 'App.Events',
@@ -44,6 +45,13 @@ export abstract class Connector {
         if (token) {
             this.options.auth.headers['X-CSRF-TOKEN'] = token;
             this.options.userAuthentication.headers['X-CSRF-TOKEN'] = token;
+        }
+
+        token = this.options.bearerToken;
+
+        if (token) {
+            this.options.auth.headers['Authorization'] = 'Bearer ' + token;
+            this.options.userAuthentication.headers['Authorization'] = 'Bearer ' + token;
         }
 
         return options;


### PR DESCRIPTION
Closes #352
Tested, this PR does not affect current functionality, also works with third party jwt tokens

>When making requests using API tokens, the token should be included in the Authorization header as a Bearer token.
>When the mobile application uses the token to make an API request to your application, it should pass the token in the Authorization header as a Bearer token. "Laravel Sanctum"
```php
Broadcast::routes(["middleware" => ['auth:api',/*'auth:sanctum',*/]]);
```
**Current**:
```ts
var TOKEN='*******';
{
  // csrfToken: '******'
  auth: {
      headers: {
          Authorization: "Bearer " + TOKEN
      },
  },
  userAuthentication: {
      headers: {
          Authorization: "Bearer " + TOKEN
      },
  },
}
```
**New**(Shorter):
```ts
{
  // csrfToken: '******'
  bearerToken: '*******',
}
```

**Sources:**
https://laravel.com/docs/9.x/sanctum#issuing-api-tokens
PR: [9.x] User authentication for Pusher framework#42531
`signin()` method: https://pusher.com/docs/channels/using_channels/user-authentication/#sign-in
https://github.com/laravel/echo/issues/189#issuecomment-1151122757
https://github.com/laravel/echo/issues/26#issuecomment-313898800
https://github.com/laravel/echo/issues/26#issuecomment-320472148
https://github.com/laravel/echo/issues/26#issuecomment-370832818
https://github.com/laravel/echo/issues/26#issuecomment-394170044
https://github.com/laravel/echo/issues/282#issuecomment-670778544
https://github.com/laravel/echo/issues/219#issue-396205561

```batch
> npm run compile && npm run declarations
> laravel-echo@1.[13](https://github.com/laravel/echo/runs/8038132230?check_suite_focus=true#step:6:14).1 compile
> ./node_modules/.bin/rollup -c
./src/echo.ts → ./dist/echo.js, ./dist/echo.common.js...
(!) Mixing named and default exports
https://rollupjs.org/guide/en/#outputexports
The following entry modules are using named and default exports together:
src/echo.ts

Consumers of your bundle will have to use chunk['default'] to access their default export, which may not be what you want. Use `output.exports: 'named'` to disable this warning
created ./dist/echo.js, ./dist/echo.common.js in 4.5s
```