### PR TITLE
Add support for centrifuge-js

### DIFF
--- a/src/channel/centrifuge-channel.ts
+++ b/src/channel/centrifuge-channel.ts
@@ -1,0 +1,188 @@
+import { EventFormatter } from '../util';
+import { Channel } from './channel';
+
+/**
+ * This class represents a Pusher channel.
+ */
+export class CentrifugeChannel extends Channel {
+    /**
+     * The Centrifuge client instance.
+     */
+    centrifuge: any;
+
+    /**
+     * The subscription instance
+     */
+    subscription: any;
+
+    /**
+     * The name of the channel.
+     */
+    name: any;
+
+    /**
+     * Channel options.
+     */
+    options: any;
+
+    /**
+     * The event formatter.
+     */
+    eventFormatter: EventFormatter;
+
+    /**
+     * The event callbacks applied to the socket.
+     */
+    events: any = {};
+
+    /**
+     * User supplied callbacks for events on this channel.
+     */
+    private listeners: any = {};
+
+    private getTokenCallback: any;
+
+    /**
+     * Create a new class instance.
+     */
+    constructor(centrifuge: any, name: string, options: any) {
+        super();
+
+        this.name = name;
+        this.centrifuge = centrifuge;
+        this.options = options;
+        this.eventFormatter = new EventFormatter(this.options.namespace);
+
+        this.getTokenCallback =
+            options.getTokenCallback ||
+            function (ctx) {
+                return new Promise((resolve, reject) => {
+                    axios
+                        .get('/broadcasting/auth', { params: ctx })
+                        .then((rsp) => {
+                            resolve(rsp.data.token);
+                        })
+                        .catch((err) => {
+                            reject(err);
+                        });
+                });
+            };
+
+        this.subscribe();
+    }
+
+    /**
+     * Subscribe to a Centrifuge channel.
+     */
+    subscribe(): void {
+        if (this.centrifuge.getSubscription(this.name) !== null) {
+            return;
+        }
+
+        this.subscription = this.centrifuge.newSubscription(this.name, {
+            getToken: (ctx) => this.getTokenCallback(ctx),
+        });
+
+        this.subscription.subscribe();
+
+        this.subscription.on('publication', (ctx) => {
+            if (ctx.data.event in this.events) {
+                this.events[ctx.data.event](ctx.data.channel, ctx.data);
+            }
+        });
+    }
+
+    /**
+     * Unsubscribe from channel and ubind event callbacks.
+     */
+    unsubscribe(): void {
+        this.unbind();
+
+        this.subscription.unsubscribe();
+    }
+
+    /**
+     * Listen for an event on the channel instance.
+     */
+    listen(event: string, callback: Function): CentrifugeChannel {
+        this.on(this.eventFormatter.format(event), callback);
+
+        return this;
+    }
+
+    /**
+     * Stop listening for an event on the channel instance.
+     */
+    stopListening(event: string, callback?: Function): CentrifugeChannel {
+        this.unbindEvent(this.eventFormatter.format(event), callback);
+
+        return this;
+    }
+
+    /**
+     * Register a callback to be called anytime a subscription succeeds.
+     */
+    subscribed(callback: Function): CentrifugeChannel {
+        this.subscription.on('subscribed', (socket) => {
+            callback(socket);
+        });
+
+        return this;
+    }
+
+    /**
+     * Register a callback to be called anytime an error occurs.
+     */
+    error(callback: Function): CentrifugeChannel {
+        this.subscription.on('error', (ctx) => callback(ctx));
+
+        return this;
+    }
+
+    /**
+     * Bind the channel's socket to an event and store the callback.
+     */
+    on(event: string, callback: Function): CentrifugeChannel {
+        this.listeners[event] = this.listeners[event] || [];
+
+        if (!this.events[event]) {
+            this.events[event] = (channel, data) => {
+                if (this.name === channel && this.listeners[event]) {
+                    this.listeners[event].forEach((cb) => cb(data));
+                }
+            };
+        }
+
+        this.listeners[event].push(callback);
+
+        return this;
+    }
+
+    /**
+     * Unbind the channel's socket from all stored event callbacks.
+     */
+    unbind(): void {
+        Object.keys(this.events).forEach((event) => {
+            this.unbindEvent(event);
+        });
+    }
+
+    /**
+     * Unbind the listeners for the given event.
+     */
+    protected unbindEvent(event: string, callback?: Function): void {
+        this.listeners[event] = this.listeners[event] || [];
+
+        if (callback) {
+            this.listeners[event] = this.listeners[event].filter((cb) => cb !== callback);
+        }
+
+        if (!callback || this.listeners[event].length === 0) {
+            if (this.events[event]) {
+                delete this.events[event];
+            }
+
+            delete this.listeners[event];
+        }
+    }
+}

--- a/src/channel/centrifuge-channel.ts
+++ b/src/channel/centrifuge-channel.ts
@@ -87,7 +87,7 @@ export class CentrifugeChannel extends Channel {
 
         this.subscription.on('publication', (ctx) => {
             if (ctx.data.event in this.events) {
-                this.events[ctx.data.event](ctx.data.channel, ctx.data);
+                this.events[ctx.data.event](ctx.channel, ctx.data);
             }
         });
     }

--- a/src/channel/centrifuge-presence-channel.ts
+++ b/src/channel/centrifuge-presence-channel.ts
@@ -1,0 +1,35 @@
+import { PresenceChannel } from './presence-channel';
+import { CentrifugeChannel } from './centrifuge-channel';
+
+/**
+ * This class represents a Centrifuge channel.
+ */
+export class CentrifugePresenceChannel extends CentrifugeChannel implements PresenceChannel {
+    /**
+     * Register a callback to be called anytime the member list changes.
+     */
+    here(callback: Function): CentrifugePresenceChannel {
+        this.joining(callback);
+        this.leaving(callback);
+
+        return this;
+    }
+
+    /**
+     * Listen for someone joining the channel.
+     */
+    joining(callback: Function): CentrifugePresenceChannel {
+        this.on('join', (ctx) => callback(ctx.info));
+
+        return this;
+    }
+
+    /**
+     * Listen for someone leaving the channel.
+     */
+    leaving(callback: Function): CentrifugePresenceChannel {
+        this.on('leave', (ctx) => callback(ctx.info));
+
+        return this;
+    }
+}

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -10,3 +10,5 @@ export * from './socketio-presence-channel';
 export * from './null-channel';
 export * from './null-private-channel';
 export * from './null-presence-channel';
+export * from './centrifuge-channel';
+export * from './centrifuge-presence-channel';

--- a/src/connector/centrifuge-connector.ts
+++ b/src/connector/centrifuge-connector.ts
@@ -31,6 +31,8 @@ export class CentrifugeConnector extends Connector {
                 'Centrifuge-js client not found. Should be globally available or passed via options.client'
             );
         }
+
+        this.centrifuge.connect();
     }
 
     /**

--- a/src/connector/centrifuge-connector.ts
+++ b/src/connector/centrifuge-connector.ts
@@ -1,0 +1,104 @@
+import { Connector } from './connector';
+import { CentrifugePresenceChannel, CentrifugeChannel } from '../channel';
+
+/**
+ * This class creates a connnector to a Centrifugal server.
+ */
+export class CentrifugeConnector extends Connector {
+    /**
+     * The Socket.io connection instance.
+     * @type Centrifuge
+     */
+    centrifuge: any;
+
+    /**
+     * All of the subscribed channel names.
+     */
+    channels: { [name: string]: CentrifugePresenceChannel } = {};
+
+    /**
+     * Create a fresh Socket.io connection.
+     */
+    connect(): void {
+        if (typeof this.options.client !== 'undefined') {
+            this.centrifuge = this.options.client;
+        } else if (this.options.Centrifuge) {
+            this.centrifuge = new this.options.Centrifuge(this.options.host, this.options);
+        } else if ('Centrifuge' in window) {
+            this.centrifuge = new Centrifuge(this.options.host, this.options);
+        } else {
+            throw new Error(
+                'Centrifuge-js client not found. Should be globally available or passed via options.client'
+            );
+        }
+    }
+
+    /**
+     * Listen for an event on a channel instance.
+     */
+    listen(name: string, event: string, callback: Function): CentrifugeChannel {
+        return this.channel(name).listen(event, callback);
+    }
+
+    /**
+     * Get a channel instance by name.
+     */
+    channel(name: string): CentrifugeChannel {
+        if (!this.channels[name]) {
+            this.channels[name] = new CentrifugePresenceChannel(this.centrifuge, name, this.options);
+        }
+
+        return this.channels[name];
+    }
+
+    /**
+     * Get a private channel instance by name.
+     */
+    privateChannel(name: string): CentrifugeChannel {
+        return this.channel(name);
+    }
+
+    /**
+     * Get a presence channel instance by name.
+     */
+    presenceChannel(name: string): CentrifugePresenceChannel {
+        if (!this.channels[name]) {
+            this.channels[name] = new CentrifugePresenceChannel(this.centrifuge, name, this.options);
+        }
+
+        return this.channels[name];
+    }
+
+    /**
+     * Leave the given channel, as well as its private and presence variants.
+     */
+    leave(name: string): void {
+        let channels = [name, 'private-' + name, 'presence-' + name];
+
+        channels.forEach((name) => {
+            this.leaveChannel(name);
+        });
+    }
+
+    /**
+     * Leave the given channel.
+     */
+    leaveChannel(name: string): void {
+        if (this.channels[name]) {
+            this.channels[name].unsubscribe();
+
+            delete this.channels[name];
+        }
+    }
+
+    /**
+     * Disconnect Socketio connection.
+     */
+    disconnect(): void {
+        this.centrifuge.disconnect();
+    }
+
+    socketId(): string {
+        return '';
+    }
+}

--- a/src/connector/index.ts
+++ b/src/connector/index.ts
@@ -2,3 +2,4 @@ export * from './connector';
 export * from './pusher-connector';
 export * from './socketio-connector';
 export * from './null-connector';
+export * from './centrifuge-connector';

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,5 +1,5 @@
 import { Channel, PresenceChannel } from './channel';
-import { PusherConnector, SocketIoConnector, NullConnector } from './connector';
+import { PusherConnector, SocketIoConnector, NullConnector, CentrifugeConnector } from './connector';
 
 /**
  * This class is the primary API for interacting with broadcasting.
@@ -44,6 +44,8 @@ export default class Echo {
             this.connector = new SocketIoConnector(this.options);
         } else if (this.options.broadcaster == 'null') {
             this.connector = new NullConnector(this.options);
+        } else if (this.options.broadcaster == 'centrifuge') {
+            this.connector = new CentrifugeConnector(this.options);
         } else if (typeof this.options.broadcaster == 'function') {
             this.connector = new this.options.broadcaster(this.options);
         }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4,3 +4,4 @@ declare let Vue: any;
 declare let axios: any;
 declare let jQuery: any;
 declare let Turbo: any;
+declare let Centrifuge: any;


### PR DESCRIPTION
@Opekunov recently released a broadcast driver for [Centrifugo](https://github.com/Opekunov/laravel-centrifugo-broadcaster), allowing us to use it in Laravel, so I thought I would add support for [centrifuge-js](https://github.com/centrifugal/centrifuge-js) to Echo.

The centrifuge-js docs are a bit difficult to understand, so adding it to Echo will allow more developers to use this awesome piece of software with Laravel.