### PR TITLE
Fix TS error in EventFormatter for projects using TS5

### DIFF
--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -3,15 +3,10 @@
  */
 export class EventFormatter {
     /**
-     * Event namespace.
-     */
-    namespace: string | boolean;
-
-    /**
      * Create a new class instance.
      */
-    constructor(namespace: string | boolean) {
-        this.setNamespace(namespace);
+    constructor(private namespace: string | boolean) {
+        //
     }
 
     /**


### PR DESCRIPTION
This PR fixes the following error the TS compiler throws when using Echo in our TS5 project:
![image](https://github.com/laravel/echo/assets/9074391/e3b0cf72-6ea2-40fc-a63d-8b03d43b1e62)

Because the `namespace` property is initialised without a value and set indirectly via a method call in the constructor, the TS compiler is complaining. 

This PR proposes the solution to promote the property in the constructor. I have selected private as the access level because I couldn't find any public usages inside the repo, and also can't imagine a use case why anyone would modify this publicly (instead of using the provided `setNamespace` method). It's also an option to promote it to a public property, that would also fix the issue.

It's possible this error on occurs in certain TS5 configs. We run TS5 with WebPack (Mix) and some ignored deprecations, so it might not cause issues for TS5 users with a different resolution or config. I don't think this fix has downsides, though.