### PR TITLE
Export `Connector` and `EventFormatter` to provide full extensibility

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -1,5 +1,5 @@
 import { Channel, PresenceChannel } from './channel';
-import { PusherConnector, SocketIoConnector, NullConnector } from './connector';
+import { Connector, PusherConnector, SocketIoConnector, NullConnector } from './connector';
 
 /**
  * This class is the primary API for interacting with broadcasting.
@@ -188,4 +188,6 @@ export default class Echo {
 /**
  * Export channel classes for TypeScript.
  */
-export { Channel, PresenceChannel };
+export { Connector, Channel, PresenceChannel };
+
+export { EventFormatter } from './util';


### PR DESCRIPTION
During the development of a custom Echo connector, we needed [`Connector` and `EventFormatter`](https://github.com/qruto/laravel-wave-client/tree/main/src/echo) to achieve the desired functionality. Including these exports would be beneficial.