### PR TITLE
Add redisPrefix Option for Laravel Echo Socket.io Redis Connection 

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -1,4 +1,4 @@
-import { Channel, PresenceChannel } from './../channel';
+import { Channel, PresenceChannel } from '../channel';
 
 export abstract class Connector {
     /**

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -18,6 +18,7 @@ export abstract class Connector {
         bearerToken: null,
         host: null,
         key: null,
+        redisPrefix: null,
         namespace: 'App.Events',
     };
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -18,7 +18,6 @@ export abstract class Connector {
         bearerToken: null,
         host: null,
         key: null,
-        redisPrefix: undefined,
         namespace: 'App.Events',
     };
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -18,7 +18,7 @@ export abstract class Connector {
         bearerToken: null,
         host: null,
         key: null,
-        redisPrefix: null,
+        redisPrefix: undefined,
         namespace: 'App.Events',
     };
 

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -15,7 +15,7 @@ export class SocketIoConnector extends Connector {
      */
     channels: { [name: string]: SocketIoChannel } = {};
 
-    redisPrefix = this.options.redisPrefix ?? ''
+    redisPrefix = this.options.redisPrefix ?? '';
 
     /**
      * Create a fresh Socket.io connection.

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -15,7 +15,7 @@ export class SocketIoConnector extends Connector {
      */
     channels: { [name: string]: SocketIoChannel } = {};
 
-    redisPrefix = this.options.redisPrefix
+    redisPrefix = this.options.redisPrefix??''
 
     /**
      * Create a fresh Socket.io connection.

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -1,5 +1,5 @@
-import { Connector } from './connector';
-import { SocketIoChannel, SocketIoPrivateChannel, SocketIoPresenceChannel } from './../channel';
+import {Connector} from './connector';
+import {SocketIoChannel, SocketIoPrivateChannel, SocketIoPresenceChannel} from './../channel';
 
 /**
  * This class creates a connnector to a Socket.io server.
@@ -14,6 +14,8 @@ export class SocketIoConnector extends Connector {
      * All of the subscribed channel names.
      */
     channels: { [name: string]: SocketIoChannel } = {};
+
+    redisPrefix = this.options.redisPrefix + '_'
 
     /**
      * Create a fresh Socket.io connection.
@@ -58,10 +60,10 @@ export class SocketIoConnector extends Connector {
      * Get a channel instance by name.
      */
     channel(name: string): SocketIoChannel {
+        name = this.redisPrefix + name;
         if (!this.channels[name]) {
             this.channels[name] = new SocketIoChannel(this.socket, name, this.options);
         }
-
         return this.channels[name];
     }
 
@@ -70,10 +72,10 @@ export class SocketIoConnector extends Connector {
      */
     privateChannel(name: string): SocketIoPrivateChannel {
         if (!this.channels['private-' + name]) {
-            this.channels['private-' + name] = new SocketIoPrivateChannel(this.socket, 'private-' + name, this.options);
+            name = this.redisPrefix + 'private-' + name;
+            this.channels[name] = new SocketIoPrivateChannel(this.socket, name, this.options);
         }
-
-        return this.channels['private-' + name] as SocketIoPrivateChannel;
+        return this.channels[name] as SocketIoPrivateChannel;
     }
 
     /**
@@ -81,21 +83,21 @@ export class SocketIoConnector extends Connector {
      */
     presenceChannel(name: string): SocketIoPresenceChannel {
         if (!this.channels['presence-' + name]) {
-            this.channels['presence-' + name] = new SocketIoPresenceChannel(
+            name = this.redisPrefix + 'private-' + name;
+            this.channels[name] = new SocketIoPresenceChannel(
                 this.socket,
-                'presence-' + name,
+                name,
                 this.options
             );
         }
-
-        return this.channels['presence-' + name] as SocketIoPresenceChannel;
+        return this.channels[name] as SocketIoPresenceChannel;
     }
 
     /**
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [name, 'private-' + name, 'presence-' + name];
+        let channels = [name, this.redisPrefix + 'private-' + name, this.redisPrefix + 'presence-' + name];
 
         channels.forEach((name) => {
             this.leaveChannel(name);

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -97,7 +97,7 @@ export class SocketIoConnector extends Connector {
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [name, this.redisPrefix + 'private-' + name, this.redisPrefix + 'presence-' + name];
+        let channels = [this.redisPrefix + name, this.redisPrefix + 'private-' + name, this.redisPrefix + 'presence-' + name];
 
         channels.forEach((name) => {
             this.leaveChannel(name);

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -15,7 +15,7 @@ export class SocketIoConnector extends Connector {
      */
     channels: { [name: string]: SocketIoChannel } = {};
 
-    redisPrefix = this.options.redisPrefix + '_'
+    redisPrefix = this.options.redisPrefix
 
     /**
      * Create a fresh Socket.io connection.

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -15,7 +15,7 @@ export class SocketIoConnector extends Connector {
      */
     channels: { [name: string]: SocketIoChannel } = {};
 
-    redisPrefix = this.options.redisPrefix??''
+    redisPrefix = this.options.redisPrefix ?? ''
 
     /**
      * Create a fresh Socket.io connection.
@@ -84,11 +84,7 @@ export class SocketIoConnector extends Connector {
     presenceChannel(name: string): SocketIoPresenceChannel {
         if (!this.channels['presence-' + name]) {
             name = this.redisPrefix + 'private-' + name;
-            this.channels[name] = new SocketIoPresenceChannel(
-                this.socket,
-                name,
-                this.options
-            );
+            this.channels[name] = new SocketIoPresenceChannel(this.socket, name, this.options);
         }
         return this.channels[name] as SocketIoPresenceChannel;
     }
@@ -97,7 +93,11 @@ export class SocketIoConnector extends Connector {
      * Leave the given channel, as well as its private and presence variants.
      */
     leave(name: string): void {
-        let channels = [this.redisPrefix + name, this.redisPrefix + 'private-' + name, this.redisPrefix + 'presence-' + name];
+        let channels = [
+            this.redisPrefix + name,
+            this.redisPrefix + 'private-' + name,
+            this.redisPrefix + 'presence-' + name,
+        ];
 
         channels.forEach((name) => {
             this.leaveChannel(name);

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -1,8 +1,8 @@
-import {Connector} from './connector';
-import {SocketIoChannel, SocketIoPrivateChannel, SocketIoPresenceChannel} from './../channel';
+import { Connector } from './connector';
+import { SocketIoChannel, SocketIoPrivateChannel, SocketIoPresenceChannel } from '../channel';
 
 /**
- * This class creates a connnector to a Socket.io server.
+ * This class creates a connector to a Socket.io server.
  */
 export class SocketIoConnector extends Connector {
     /**
@@ -11,7 +11,7 @@ export class SocketIoConnector extends Connector {
     socket: any;
 
     /**
-     * All of the subscribed channel names.
+     * All the subscribed channel names.
      */
     channels: { [name: string]: SocketIoChannel } = {};
 


### PR DESCRIPTION
Fix #232

### Summary

This Pull Request introduces the `redisPrefix` option, enhancing the Laravel Echo's ability to connect to a Socket.io server using Redis as a broker with an additional prefix, facilitating improved management and segregation of WebSocket channels.

### Background

In certain scenarios, especially in larger or shared Redis environments, differentiating between various connections or channels via a prefix becomes crucial. A prefix can provide a clear distinction and manage channels more efficiently by avoiding possible naming conflicts or overlaps. This ensures clean and error-free data flow between numerous channels and connections, thereby promoting a more stable and reliable real-time communication setup.

Moreover, the redisPrefix feature facilitates the utilization of Socket.io directly, eliminating the necessity of the laravel-echo-server package. This adjustment not only simplifies the stack but also broadens the compatibility and adaptability of the setup across various environments and use-cases.

Developers, particularly those managing multiple applications or instances that communicate via a common Redis instance, stand to benefit significantly from this feature. It assures seamless communication and interaction between the client and server, maintaining the integrity and order of transmitted data, even in more complex or shared digital ecosystems.

### Changes Introduced

- Added a new `redisPrefix` option in the connection configuration.
- Updated relevant connection and communication mechanisms to utilize the prefixed channels when `redisPrefix` is set.

### How it works

The `redisPrefix` option allows the developer to specify a prefix that will be used for all Redis channels established. This is particularly useful in environments where a Redis server is shared amongst several applications or different instances of the same application to avoid channel naming conflicts.

### Usage Example

```javascript
import Echo from "laravel-echo";
import io from 'socket.io-client';

window.Echo = new Echo({
    broadcaster: 'socket.io',
    host: window.location.hostname + ':3000',
    client: io,
    redisPrefix: 'laravel_database_
});
```

In the example above, laravel_database_: will be prefixed to all channel names managed by this Laravel Echo instance.

### Impact
This is the solution to allow using own socket.io server implementation and make it works with broadcast redis driver at ease.
This feature allows for cleaner management of Redis channels in shared environments and ensures that applications can coexist on the same Redis server without interfering with one another’s messaging channels. Dedicated especially for those who want run their own socket.io server instance and make it work with laravel.

 
### Testing
The changes have been tested with the following package versions to ensure compatibility and stability:

- `"laravel/framework": "^10.0"`
- `"socket.io": "^4.7.2"`
- `"laravel-echo":"^1.15.3"`
- `"socket.io-client": "^4.7.2"`
- `"ioredis": "^5.3.2"`
- `"@socket.io/redis-adapter": "^8.2.1"`

It is advisable to conduct further testing on different versions to ensure broader compatibility. However leaving option undefined make code mostly like it was before, so the change will only help those who would like to work with socket.io server and will not disturb others.


