### PR TITLE
Refactor channels names(only readability fix)

### DIFF
--- a/src/connector/pusher-connector.ts
+++ b/src/connector/pusher-connector.ts
@@ -63,41 +63,39 @@ export class PusherConnector extends Connector {
      * Get a private channel instance by name.
      */
     privateChannel(name: string): PusherChannel {
-        if (!this.channels['private-' + name]) {
-            this.channels['private-' + name] = new PusherPrivateChannel(this.pusher, 'private-' + name, this.options);
+        name = 'private-' + name;
+
+        if (!this.channels[name]) {
+            this.channels[name] = new PusherPrivateChannel(this.pusher, name, this.options);
         }
 
-        return this.channels['private-' + name];
+        return this.channels[name];
     }
 
     /**
      * Get a private encrypted channel instance by name.
      */
     encryptedPrivateChannel(name: string): PusherChannel {
-        if (!this.channels['private-encrypted-' + name]) {
-            this.channels['private-encrypted-' + name] = new PusherEncryptedPrivateChannel(
-                this.pusher,
-                'private-encrypted-' + name,
-                this.options
-            );
+        name = 'private-encrypted-' + name;
+
+        if (!this.channels[name]) {
+            this.channels[name] = new PusherEncryptedPrivateChannel(this.pusher, name, this.options);
         }
 
-        return this.channels['private-encrypted-' + name];
+        return this.channels[name];
     }
 
     /**
      * Get a presence channel instance by name.
      */
     presenceChannel(name: string): PresenceChannel {
-        if (!this.channels['presence-' + name]) {
-            this.channels['presence-' + name] = new PusherPresenceChannel(
-                this.pusher,
-                'presence-' + name,
-                this.options
-            );
+        name = 'presence-' + name;
+
+        if (!this.channels[name]) {
+            this.channels[name] = new PusherPresenceChannel(this.pusher, name, this.options);
         }
 
-        return this.channels['presence-' + name];
+        return this.channels[name];
     }
 
     /**

--- a/src/connector/socketio-connector.ts
+++ b/src/connector/socketio-connector.ts
@@ -69,26 +69,26 @@ export class SocketIoConnector extends Connector {
      * Get a private channel instance by name.
      */
     privateChannel(name: string): SocketIoPrivateChannel {
-        if (!this.channels['private-' + name]) {
-            this.channels['private-' + name] = new SocketIoPrivateChannel(this.socket, 'private-' + name, this.options);
+        name = 'private-' + name;
+
+        if (!this.channels[name]) {
+            this.channels[name] = new SocketIoPrivateChannel(this.socket, name, this.options);
         }
 
-        return this.channels['private-' + name] as SocketIoPrivateChannel;
+        return this.channels[name] as SocketIoPrivateChannel;
     }
 
     /**
      * Get a presence channel instance by name.
      */
     presenceChannel(name: string): SocketIoPresenceChannel {
-        if (!this.channels['presence-' + name]) {
-            this.channels['presence-' + name] = new SocketIoPresenceChannel(
-                this.socket,
-                'presence-' + name,
-                this.options
-            );
+        name = 'presence-' + name;
+
+        if (!this.channels[name]) {
+            this.channels[name] = new SocketIoPresenceChannel(this.socket, name, this.options);
         }
 
-        return this.channels['presence-' + name] as SocketIoPresenceChannel;
+        return this.channels[name] as SocketIoPresenceChannel;
     }
 
     /**


### PR DESCRIPTION
This PR only adds better readability,
avoid repeating the same code many times
Is there any reason to repeat names like that?


```ts
//before
if (!this.channels['private-' + name]) {
    this.channels['private-' + name] = new PusherPrivateChannel(this.pusher, 'private-' + name, this.options);
}
//after
name = 'private-' + name;
if (!this.channels[name]) {
    this.channels[name] = new PusherPrivateChannel(this.pusher, name, this.options);
}
```