### PR TITLE
Adds support for Reverb as an Echo broadcaster

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -38,7 +38,9 @@ export default class Echo {
      * Create a new connection.
      */
     connect(): void {
-        if (this.options.broadcaster == 'pusher') {
+        if (this.options.broadcaster == 'reverb') {
+            this.connector = new PusherConnector({ ...this.options, cluster: '' });
+        } else if (this.options.broadcaster == 'pusher') {
             this.connector = new PusherConnector(this.options);
         } else if (this.options.broadcaster == 'socket.io') {
             this.connector = new SocketIoConnector(this.options);


### PR DESCRIPTION
This pull request adds support for Reverb as an Echo broadcaster.

Under the hood, Reverb will use the existing Pusher connector while explicitly setting the `cluster` option which avoids an error being returned from the Pusher SDK and means it doesn't have to be configured in the environment or manually when instantiating Echo.
