### PR TITLE
Replaced deprecated substr function

### DIFF
--- a/src/util/event-formatter.ts
+++ b/src/util/event-formatter.ts
@@ -13,8 +13,8 @@ export class EventFormatter {
      * Format the given event name.
      */
     format(event: string): string {
-        if (event.charAt(0) === '.' || event.charAt(0) === '\\') {
-            return event.substr(1);
+        if (['.', '\\'].includes(event.charAt(0))) {
+            return event.substring(1);
         } else if (this.namespace) {
             event = this.namespace + '.' + event;
         }


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Replace deprecated `substr` function with `substring`
