### PR TITLE
Fix custom broadcaster usages

### DIFF
--- a/src/echo.ts
+++ b/src/echo.ts
@@ -14,7 +14,7 @@ import {
     SocketIoPrivateChannel,
 } from './channel';
 import { Connector, PusherConnector, SocketIoConnector, NullConnector } from './connector';
-import {isConstructor} from "./util";
+import { isConstructor } from "./util";
 
 /**
  * This class is the primary API for interacting with broadcasting.

--- a/src/echo.ts
+++ b/src/echo.ts
@@ -14,6 +14,7 @@ import {
     SocketIoPrivateChannel,
 } from './channel';
 import { Connector, PusherConnector, SocketIoConnector, NullConnector } from './connector';
+import {isConstructor} from "./util";
 
 /**
  * This class is the primary API for interacting with broadcasting.
@@ -60,8 +61,8 @@ export default class Echo<T extends keyof Broadcaster> {
             this.connector = new SocketIoConnector(this.options);
         } else if (this.options.broadcaster == 'null') {
             this.connector = new NullConnector(this.options);
-        } else if (typeof this.options.broadcaster == 'function') {
-            this.connector = this.options.broadcaster(this.options as EchoOptions<'function'>);
+        } else if (typeof this.options.broadcaster == 'function' && isConstructor(this.options.broadcaster)) {
+            this.connector = new this.options.broadcaster(this.options as EchoOptions<'function'>);
         } else {
             throw new Error(
                 `Broadcaster ${typeof this.options.broadcaster} ${this.options.broadcaster} is not supported.`
@@ -261,11 +262,13 @@ type Broadcaster = {
     };
 };
 
+type Constructor<T = {}> = new (...args: any[]) => T;
+
 type EchoOptions<T extends keyof Broadcaster> = {
     /**
      * The broadcast connector.
      */
-    broadcaster: T extends 'function' ? (options: EchoOptions<T>) => any : T;
+    broadcaster: T extends 'function' ? Constructor<InstanceType<Broadcaster[T]['connector']>> : T;
 
     [key: string]: any;
 };

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,1 +1,11 @@
+function isConstructor(obj: any): obj is new (...args: any[]) => any {
+    try {
+        new obj();
+    } catch (err) {
+        if (err.message.includes('is not a constructor')) return false;
+    }
+    return true;
+}
+
+export {isConstructor};
 export * from './event-formatter';

--- a/tests/echo.test.ts
+++ b/tests/echo.test.ts
@@ -1,4 +1,5 @@
 import Echo from '../src/echo';
+import {PusherConnector} from "../src/connector";
 
 describe('Echo', () => {
     test('it will not throw error for supported driver', () => {
@@ -10,12 +11,18 @@ describe('Echo', () => {
             'Broadcaster string pusher is not supported.'
         );
 
+        expect(() => new Echo({ broadcaster: PusherConnector })).not.toThrowError(
+            'Broadcaster string pusher is not supported.'
+        );
+
         expect(() => new Echo({ broadcaster: 'socket.io' })).not.toThrowError(
             'Broadcaster string socket.io is not supported.'
         );
 
         expect(() => new Echo({ broadcaster: 'null' })).not.toThrowError('Broadcaster string null is not supported.');
 
+        // eslint-disable-next-line
+        // @ts-ignore
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         expect(() => new Echo({ broadcaster: () => {} })).not.toThrowError('Broadcaster function is not supported.');
     });

--- a/tests/echo.test.ts
+++ b/tests/echo.test.ts
@@ -1,5 +1,5 @@
 import Echo from '../src/echo';
-import {PusherConnector} from "../src/connector";
+import {NullConnector, PusherConnector} from "../src/connector";
 
 describe('Echo', () => {
     test('it will not throw error for supported driver', () => {
@@ -11,15 +11,12 @@ describe('Echo', () => {
             'Broadcaster string pusher is not supported.'
         );
 
-        expect(() => new Echo({ broadcaster: PusherConnector })).not.toThrowError(
-            'Broadcaster string pusher is not supported.'
-        );
-
         expect(() => new Echo({ broadcaster: 'socket.io' })).not.toThrowError(
             'Broadcaster string socket.io is not supported.'
         );
 
         expect(() => new Echo({ broadcaster: 'null' })).not.toThrowError('Broadcaster string null is not supported.');
+        expect(() => new Echo({ broadcaster: NullConnector })).not.toThrowError();
 
         // eslint-disable-next-line
         // @ts-ignore

--- a/tests/echo.test.ts
+++ b/tests/echo.test.ts
@@ -1,5 +1,5 @@
 import Echo from '../src/echo';
-import {NullConnector, PusherConnector} from "../src/connector";
+import { NullConnector } from "../src/connector";
 
 describe('Echo', () => {
     test('it will not throw error for supported driver', () => {


### PR DESCRIPTION
Support for custom broadcasters was added in https://github.com/laravel/echo/pull/247 but usage wasn't documented, and tests weren't added.

In https://github.com/laravel/echo/pull/403/commits/820ab6e130b24993294efef715adcfd5ff1c75fd the way custom broadcasters can be implemented changed, due to the removal of the `new` keyword. This was raised on the PR:
> **6. Function Broadcaster**
This is a bigger question mark for me. The tests show that a simple function can be used as a broadcaster. The code however calls this function and attempts to construct whatever comes out of it. I am not sure where function broadcasters are used but I couldn't find any documentation on it. The problem here is that TypeScript complains and says "Since you are using `new broadcaster()`, whatever comes out of broadcaster must be a constructable". But the function that is passed as an example in the tests is not a constructable. So I can either satisfy the tests or the types.
> 
> In my understanding the function broadcaster enables users to write any kind of function that creates a custom connector and Echo will then use this connector. In this case I don't think the `new` is necessary here, so I removed it. At the same time the connector and channel types for the function broadcaster are now `any`. We would assume that the custom connector will have the same methods as other connectors but technically the user could `return 'foobar';` in there and we will never know for sure.

I've fixed the type errors and reverted the removal of the `new` keyword, so that usages remain as before.