### PR TITLE
[1.x] Replaces deprecated auth options for default Pusher

### DIFF
--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -43,14 +43,14 @@ export abstract class Connector<TPublic extends Channel, TPrivate extends Channe
         let token = this.csrfToken();
 
         if (token) {
-            this.options.auth.headers['X-CSRF-TOKEN'] = token;
+            this.options.channelAuthorization.headers['X-CSRF-TOKEN'] = token;
             this.options.userAuthentication.headers['X-CSRF-TOKEN'] = token;
         }
 
         token = this.options.bearerToken;
 
         if (token) {
-            this.options.auth.headers['Authorization'] = 'Bearer ' + token;
+            this.options.channelAuthorization.headers['Authorization'] = 'Bearer ' + token;
             this.options.userAuthentication.headers['Authorization'] = 'Bearer ' + token;
         }
 

--- a/src/connector/connector.ts
+++ b/src/connector/connector.ts
@@ -5,10 +5,10 @@ export abstract class Connector<TPublic extends Channel, TPrivate extends Channe
      * Default connector options.
      */
     private _defaultOptions: any = {
-        auth: {
+        channelAuthorization: {
+            endpoint: '/broadcasting/auth',
             headers: {},
         },
-        authEndpoint: '/broadcasting/auth',
         userAuthentication: {
             endpoint: '/broadcasting/user-auth',
             headers: {},


### PR DESCRIPTION
While hand-porting `pusher-js` and `echo` to php for my `Resonance` package, I found that some default options we're relying on in `echo` are [explicitly deprecated](https://github.com/pusher/pusher-js/blob/master/src/core/options.ts#L17).
```ts
// pusher-js/src/core/options.ts
  auth?: DeprecatedAuthOptions; // DEPRECATED use channelAuthorization instead
  authEndpoint?: string; // DEPRECATED use channelAuthorization instead
```

This PR replaces those two properties with a new object that satisfies the [preferred interface](https://github.com/pusher/pusher-js/blob/master/src/core/auth/options.ts#L54).
```ts
// pusher-js/src/core/auth/options.ts
export interface AuthOptionsT<AuthHandler> {
  transport: 'ajax' | 'jsonp';
  endpoint: string;
  params?: any;
  headers?: any;
  paramsProvider?: () => any;
  headersProvider?: () => any;
  customHandler?: AuthHandler;
}

export declare type ChannelAuthorizationOptions = AuthOptionsT<
  ChannelAuthorizationHandler
>;
```

```diff
// echo/src/connector/connector.ts
- auth: {
-   headers: {},
-  },
- authEndpoint: '/broadcasting/auth',
+ channelAuthorization: {
+   endpoint: '/broadcasting/auth',
+   headers: {},
+ },
```

Since all of work being done with this options object is done within `pusher-js` even while being used with Reverb, this change should have no effect on compatibility with Reverb.