### PR TITLE
Fix TypeScript Error in `isConstructor`

### DIFF
--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -4,9 +4,11 @@ function isConstructor(obj: unknown): obj is new (...args: any[]) => any {
     }
 
     try {
-        Reflect.construct(String, [], obj);
+        new (obj as new (...args: any[]) => any)();
     } catch (err) {
-        return false;
+        if (err instanceof Error && err.message.includes('is not a constructor')) {
+            return false;
+        }
     }
 
     return true;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,8 +1,4 @@
 function isConstructor(obj: unknown): obj is new (...args: any[]) => any {
-    if (typeof obj !== 'function') {
-        return false;
-    }
-
     try {
         new (obj as new (...args: any[]) => any)();
     } catch (err) {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,9 +1,14 @@
-function isConstructor(obj: any): obj is new (...args: any[]) => any {
-    try {
-        new obj();
-    } catch (err) {
-        if (err.message.includes('is not a constructor')) return false;
+function isConstructor(obj: unknown): obj is new (...args: any[]) => any {
+    if (typeof obj !== 'function') {
+        return false;
     }
+
+    try {
+        Reflect.construct(String, [], obj);
+    } catch (err) {
+        return false;
+    }
+
     return true;
 }
 


### PR DESCRIPTION
This PR resolves a TypeScript error in the `isConstructor` utility function and improves error handling for enhanced type safety.

### Key Changes

1. **TypeScript Error Fix**:
   - Resolved the `TS18046: 'err' is of type 'unknown'` error by explicitly checking whether the caught `err` is an instance of `Error` before accessing its `message`.

2. **Improved Error Handling**:
   - Updated the `catch` block to specifically handle cases where `obj` is not a valid constructor by checking the error message for "is not a constructor."

3. **`unknown` instead of `any`**
   - Using `unknown` instead of `any` aligns with TypeScript best practices by forcing developers to explicitly assert or narrow types, reducing potential runtime errors.

TS error `TS18046` only happens when running TS in strict, so in the `Echo` project itself you don't see it until enabling `strict`, but our TS config falls over this library implementation, and the change is a net benefit IMO.


