### PR TITLE
[2.x] move tslib to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "socket.io-client": "^4.0",
         "standard-version": "^9.3.2",
         "ts-jest": "^29.2.5",
+        "tslib": "^2.8.1",
         "typescript": "^5.7.0"
     },
     "engines": {
@@ -67,8 +68,5 @@
     },
     "overrides": {
         "glob": "^9.0.0"
-    },
-    "dependencies": {
-        "tslib": "^2.8.1"
     }
 }


### PR DESCRIPTION
Accidentally moved `tslib` to regulars deps instead of dev when upgrading 😅 