### PR TITLE
[2.x] Fix TS errors with `skipLibCheck: false`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,12 @@
         "tslib": "^2.8.1",
         "typescript": "^5.7.0"
     },
+    "typesVersions": {
+        "*": {
+            "socket.io-client": [],
+            "pusher-js": []
+        }
+    },
     "engines": {
         "node": ">=20"
     },


### PR DESCRIPTION
## **Fix TS errors with `skipLibCheck: false` by adding `typesVersions`**

This PR fixes **TypeScript module resolution errors** that occur when a project has **`skipLibCheck: false`** set. 

Currently, if `socket.io-client` or `pusher-js` are not installed, TypeScript **still attempts to resolve them**, leading to errors like:
`TS2307: Cannot find module 'socket.io-client' or its corresponding type declarations.`


### **Fix**
- **Added `typesVersions` in `package.json`** to exclude `socket.io-client` and `pusher-js` from type resolution when missing.
- This prevents TypeScript from enforcing type checks on optional dependencies.

### **No Breaking Changes**
This **only affects TypeScript behavior** and does not impact runtime or bundled output.

### **Closes**
Fixes [#415](https://github.com/laravel/echo/issues/415)

