### PR TITLE
fixes: unable to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
         "tslib": "^2.8.1",
         "typescript": "^5.7.0"
     },
+    "peerDependencies": {
+        "socket.io-client": "*",
+        "pusher-js": "*"
+    },
     "typesVersions": {
         "*": {
             "socket.io-client": [],


### PR DESCRIPTION
Closes https://github.com/laravel/echo/issues/418 by adding `socket.io-client` and `pusher-js` as peer dependencies