### PR TITLE
[Feature Request] React: Provide event name in useEcho callback

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -76,7 +76,7 @@ export const useEcho = <
 >(
     channelName: string,
     event: string | string[] = [],
-    callback: (payload: TPayload) => void = () => {},
+    callback: (payload: TPayload, event: string) => void = () => {},
     dependencies: any[] = [],
     visibility: TVisibility = "private" as TVisibility,
 ) => {
@@ -103,7 +103,9 @@ export const useEcho = <
         }
 
         events.forEach((e) => {
-            subscription.current.stopListening(e, callbackFunc);
+            subscription.current.stopListening(e, (payload: TPayload) =>
+                callbackFunc(payload, e),
+            );
         });
 
         listening.current = false;
@@ -115,7 +117,9 @@ export const useEcho = <
         }
 
         events.forEach((e) => {
-            subscription.current.listen(e, callbackFunc);
+            subscription.current.listen(e, (payload: TPayload) =>
+                callbackFunc(payload, e),
+            );
         });
 
         listening.current = true;
@@ -255,7 +259,7 @@ export const useEchoPresence = <
 >(
     channelName: string,
     event: string | string[] = [],
-    callback: (payload: TPayload) => void = () => {},
+    callback: (payload: TPayload, event: string) => void = () => {},
     dependencies: any[] = [],
 ) => {
     return useEcho<TPayload, TDriver, "presence">(
@@ -273,7 +277,7 @@ export const useEchoPublic = <
 >(
     channelName: string,
     event: string | string[] = [],
-    callback: (payload: TPayload) => void = () => {},
+    callback: (payload: TPayload, event: string) => void = () => {},
     dependencies: any[] = [],
 ) => {
     return useEcho<TPayload, TDriver, "public">(
@@ -293,7 +297,10 @@ export const useEchoModel = <
     model: TModel,
     identifier: string | number,
     event: ModelEvents<TModel> | ModelEvents<TModel>[] = [],
-    callback: (payload: ModelPayload<TPayload>) => void = () => {},
+    callback: (
+        payload: ModelPayload<TPayload>,
+        event: string,
+    ) => void = () => {},
     dependencies: any[] = [],
 ) => {
     return useEcho<ModelPayload<TPayload>, TDriver, "private">(

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -123,18 +123,24 @@ describe("useEcho hook", async () => {
 
         const channel = echoInstance.private(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[0],
+            expect.any(Function),
+        );
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[1],
+            expect.any(Function),
+        );
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            expect.any(Function),
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            expect.any(Function),
         );
     });
 
@@ -191,7 +197,7 @@ describe("useEcho hook", async () => {
 
         expect(echoInstance.private(channelName).listen).toHaveBeenCalledWith(
             event,
-            mockCallback,
+            expect.any(Function),
         );
     });
 
@@ -252,15 +258,24 @@ describe("useEcho hook", async () => {
 
         const channel = echoInstance.private(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            event,
+            expect.any(Function),
+        );
 
         result.current.stopListening();
 
-        expect(channel.stopListening).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.stopListening).toHaveBeenCalledWith(
+            event,
+            expect.any(Function),
+        );
 
         result.current.listen();
 
-        expect(channel.listen).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            event,
+            expect.any(Function),
+        );
     });
 
     it("can manually stop listening to events", async () => {
@@ -275,7 +290,10 @@ describe("useEcho hook", async () => {
         result.current.stopListening();
 
         const channel = echoInstance.private(channelName);
-        expect(channel.stopListening).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.stopListening).toHaveBeenCalledWith(
+            event,
+            expect.any(Function),
+        );
     });
 
     it("stopListening is a no-op when not listening", async () => {
@@ -388,22 +406,22 @@ describe("useEchoModel hook", async () => {
 
         expect(channel.listen).toHaveBeenCalledWith(
             `.${events[0]}`,
-            mockCallback,
+            expect.any(Function),
         );
         expect(channel.listen).toHaveBeenCalledWith(
             `.${events[1]}`,
-            mockCallback,
+            expect.any(Function),
         );
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             `.${events[0]}`,
-            mockCallback,
+            expect.any(Function),
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             `.${events[1]}`,
-            mockCallback,
+            expect.any(Function),
         );
     });
 
@@ -532,7 +550,10 @@ describe("useEchoModel hook", async () => {
         expect(echoInstance.private).toHaveBeenCalledWith(expectedChannelName);
 
         const channel = echoInstance.private(expectedChannelName);
-        expect(channel.listen).toHaveBeenCalledWith(`.${event}`, mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            `.${event}`,
+            expect.any(Function),
+        );
     });
 
     it("events and listeners are optional", async () => {
@@ -602,18 +623,24 @@ describe("useEchoPublic hook", async () => {
 
         const channel = echoInstance.channel(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[0],
+            expect.any(Function),
+        );
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[1],
+            expect.any(Function),
+        );
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            expect.any(Function),
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            expect.any(Function),
         );
     });
 
@@ -756,18 +783,24 @@ describe("useEchoPresence hook", async () => {
 
         const channel = echoInstance.join(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[0],
+            expect.any(Function),
+        );
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[1],
+            expect.any(Function),
+        );
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            expect.any(Function),
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            expect.any(Function),
         );
     });
 


### PR DESCRIPTION
Currently, the `useEcho` hook allows subscribing to multiple events with a single callback:

```
const { listen } = useEcho(
    'channel',
    ["UserCreated", "UserUpdated"],
    (payload) => {
        console.log(payload);
    }
);
```

While functional, this makes it impossible to determine which specific event was triggered, especially when handling multiple events that share similar payload structures.

This PR enhances the useEcho hook by passing the event name as a second argument to the callback:

```
const { listen } = useEcho(
    'channel',
    ["UserCreated", "UserUpdated"],
    (payload, event) => {
        // `event` will be "UserCreated" or "UserUpdated"
        console.log(payload, event);
    }
);
```

**Benefits to end users**
Enables precise event handling when listening to multiple events.

Reduces the need for workarounds such as including the event name in the payload manually.

**Backward compatibility**
The change is backward-compatible: existing usage with a single payload parameter remains functional.

Additional data (event) is non-breaking and optional for the callback.

**NOTE**: I had to adapt the tests since the registered function is now anonymous. Verifying that the original mockCallback was passed directly no longer works as before. I'm not entirely sure how you'd prefer this to be tested—if you have a specific approach in mind, I'm happy to implement it accordingly. I can also add support for this feature in Vue if you think this is something you would accept as a feature.
