### PR TITLE
Added useEchoNotification hook

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -181,7 +181,17 @@ export const useEchoNotification = <
         "private",
     );
 
-    const events = toArray(event);
+    const events = useRef(
+        toArray(event)
+            .map((e) => {
+                if (e.includes(".")) {
+                    return [e, e.replace(/\./g, "\\")];
+                }
+
+                return [e, e.replace(/\\/g, ".")];
+            })
+            .flat(),
+    );
     const listening = useRef(false);
     const initialized = useRef(false);
 
@@ -191,11 +201,14 @@ export const useEchoNotification = <
                 return;
             }
 
-            if (events.length === 0 || events.includes(notification.type)) {
+            if (
+                events.current.length === 0 ||
+                events.current.includes(notification.type)
+            ) {
                 callback(notification);
             }
         },
-        dependencies.concat(events).concat([callback]),
+        dependencies.concat(events.current).concat([callback]),
     );
 
     const listen = useCallback(() => {
@@ -221,7 +234,7 @@ export const useEchoNotification = <
 
     useEffect(() => {
         listen();
-    }, dependencies.concat(events));
+    }, dependencies.concat(events.current));
 
     return {
         ...result,

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -2,13 +2,13 @@ import { type BroadcastDriver } from "laravel-echo";
 import { useCallback, useEffect, useRef } from "react";
 import { echo } from "../config";
 import type {
+    BroadcastNotification,
     Channel,
     ChannelData,
     ChannelReturnType,
     Connection,
     ModelEvents,
     ModelPayload,
-    Notification,
 } from "../types";
 import { toArray } from "../util";
 
@@ -169,11 +169,11 @@ export const useEchoNotification = <
     TDriver extends BroadcastDriver = BroadcastDriver,
 >(
     channelName: string,
-    callback: (payload: Notification<TPayload>) => void = () => {},
+    callback: (payload: BroadcastNotification<TPayload>) => void = () => {},
     event: string | string[] = [],
     dependencies: any[] = [],
 ) => {
-    const result = useEcho<Notification<TPayload>, TDriver, "private">(
+    const result = useEcho<BroadcastNotification<TPayload>, TDriver, "private">(
         channelName,
         [],
         callback,
@@ -186,7 +186,7 @@ export const useEchoNotification = <
     const initialized = useRef(false);
 
     const cb = useCallback(
-        (notification: Notification<TPayload>) => {
+        (notification: BroadcastNotification<TPayload>) => {
             if (!listening.current) {
                 return;
             }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,7 @@ export { configureEcho, echo } from "./config/index";
 export {
     useEcho,
     useEchoModel,
+    useEchoNotification,
     useEchoPresence,
     useEchoPublic,
 } from "./hooks/use-echo";

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -16,6 +16,8 @@ export type Channel = {
     visibility: "private" | "public" | "presence";
 };
 
+export type Notification<TPayload> = TPayload & { id: string; type: string };
+
 export type ChannelReturnType<
     T extends BroadcastDriver,
     V extends Channel["visibility"],

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -16,7 +16,10 @@ export type Channel = {
     visibility: "private" | "public" | "presence";
 };
 
-export type Notification<TPayload> = TPayload & { id: string; type: string };
+export type BroadcastNotification<TPayload> = TPayload & {
+    id: string;
+    type: string;
+};
 
 export type ChannelReturnType<
     T extends BroadcastDriver,

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -977,6 +977,35 @@ describe("useEchoNotification hook", async () => {
         expect(mockCallback).not.toHaveBeenCalledWith(notification3);
     });
 
+    it("handles dotted and slashed notification event types", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+        const events = [
+            "App.Notifications.First",
+            "App\\Notifications\\Second",
+        ];
+
+        renderHook(() =>
+            echoModule.useEchoNotification(channelName, mockCallback, events),
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+
+        const notificationCallback = vi.mocked(channel.notification).mock
+            .calls[0][0];
+
+        const notification1 = { type: "App\\Notifications\\First", data: {} };
+        const notification2 = { type: "App\\Notifications\\Second", data: {} };
+
+        notificationCallback(notification1);
+        notificationCallback(notification2);
+
+        expect(mockCallback).toHaveBeenCalledWith(notification1);
+        expect(mockCallback).toHaveBeenCalledWith(notification2);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
     it("accepts all notifications when no event types specified", async () => {
         const mockCallback = vi.fn();
         const channelName = "test-channel";

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -196,12 +196,21 @@ export const useEchoNotification = <
         "private",
     );
 
-    const events = toArray(event);
-    let listening = false;
-    let initialized = false;
+    const events = toArray(event)
+        .map((e) => {
+            if (e.includes(".")) {
+                return [e, e.replace(/\./g, "\\")];
+            }
+
+            return [e, e.replace(/\\/g, ".")];
+        })
+        .flat();
+
+    const listening = ref(false);
+    const initialized = ref(false);
 
     const cb = (notification: BroadcastNotification<TPayload>) => {
-        if (!listening) {
+        if (!listening.value) {
             return;
         }
 
@@ -211,24 +220,24 @@ export const useEchoNotification = <
     };
 
     const listen = () => {
-        if (listening) {
+        if (listening.value) {
             return;
         }
 
-        if (!initialized) {
+        if (!initialized.value) {
             result.channel().notification(cb);
         }
 
-        listening = true;
-        initialized = true;
+        listening.value = true;
+        initialized.value = true;
     };
 
     const stopListening = () => {
-        if (!listening) {
+        if (!listening.value) {
             return;
         }
 
-        listening = false;
+        listening.value = false;
     };
 
     onMounted(() => {

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,6 +1,7 @@
 export {
     useEcho,
     useEchoModel,
+    useEchoNotification,
     useEchoPresence,
     useEchoPublic,
 } from "./composables/useEcho";

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -16,6 +16,11 @@ export type Channel = {
     visibility: "private" | "public" | "presence";
 };
 
+export type BroadcastNotification<TPayload> = TPayload & {
+    id: string;
+    type: string;
+};
+
 export type ChannelReturnType<
     T extends BroadcastDriver,
     V extends Channel["visibility"],

--- a/packages/vue/tests/useEcho.test.ts
+++ b/packages/vue/tests/useEcho.test.ts
@@ -849,6 +849,43 @@ describe("useEchoNotification hook", async () => {
         expect(mockCallback).not.toHaveBeenCalledWith(notification3);
     });
 
+    it("handles dotted and slashed notification event types", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+        const events = [
+            "App.Notifications.First",
+            "App\\Notifications\\Second",
+        ];
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            events,
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+
+        const notificationCallback = vi.mocked(channel.notification).mock
+            .calls[0][0];
+
+        const notification1 = {
+            type: "App\\Notifications\\First",
+            data: {},
+        };
+        const notification2 = {
+            type: "App\\Notifications\\Second",
+            data: {},
+        };
+
+        notificationCallback(notification1);
+        notificationCallback(notification2);
+
+        expect(mockCallback).toHaveBeenCalledWith(notification1);
+        expect(mockCallback).toHaveBeenCalledWith(notification2);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
     it("accepts all notifications when no event types specified", async () => {
         const mockCallback = vi.fn();
         const channelName = "test-channel";

--- a/packages/vue/tests/useEcho.test.ts
+++ b/packages/vue/tests/useEcho.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent } from "vue";
 import {
     useEcho,
+    useEchoNotification,
     useEchoPresence,
     useEchoPublic,
 } from "../src/composables/useEcho";
@@ -100,11 +101,39 @@ const getPresenceTestComponent = (
     return mount(TestComponent);
 };
 
+const getNotificationTestComponent = (
+    channelName: string,
+    callback: ((data: any) => void) | undefined,
+    event: string | string[] | undefined,
+    dependencies: any[] = [],
+) => {
+    const TestComponent = defineComponent({
+        setup() {
+            configureEcho({
+                broadcaster: "null",
+            });
+
+            return {
+                ...useEchoNotification(
+                    channelName,
+                    callback,
+                    event,
+                    dependencies,
+                ),
+            };
+        },
+        template: "<div></div>",
+    });
+
+    return mount(TestComponent);
+};
+
 vi.mock("laravel-echo", () => {
     const mockPrivateChannel = {
         leaveChannel: vi.fn(),
         listen: vi.fn(),
         stopListening: vi.fn(),
+        notification: vi.fn(),
     };
 
     const mockPublicChannel = {
@@ -694,6 +723,280 @@ describe("useEchoPresence hook", async () => {
         const channelName = "test-channel";
 
         wrapper = getPresenceTestComponent(channelName, undefined, undefined);
+
+        expect(wrapper.vm.channel).not.toBeNull();
+    });
+});
+
+describe("useEchoNotification hook", async () => {
+    let echoInstance: Echo<"null">;
+    let wrapper: ReturnType<typeof getNotificationTestComponent>;
+
+    beforeEach(async () => {
+        vi.resetModules();
+
+        echoInstance = new Echo({
+            broadcaster: "null",
+        });
+    });
+
+    afterEach(() => {
+        wrapper.unmount();
+        vi.clearAllMocks();
+    });
+
+    it("subscribes to a private channel and listens for notifications", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        expect(wrapper.vm).toHaveProperty("leaveChannel");
+        expect(typeof wrapper.vm.leaveChannel).toBe("function");
+
+        expect(wrapper.vm).toHaveProperty("leave");
+        expect(typeof wrapper.vm.leave).toBe("function");
+
+        expect(wrapper.vm).toHaveProperty("listen");
+        expect(typeof wrapper.vm.listen).toBe("function");
+
+        expect(wrapper.vm).toHaveProperty("stopListening");
+        expect(typeof wrapper.vm.stopListening).toBe("function");
+    });
+
+    it("sets up a notification listener on a channel", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        expect(echoInstance.private).toHaveBeenCalledWith(channelName);
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+    });
+
+    it("handles notification filtering by event type", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+        const eventType = "specific-type";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            eventType,
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+
+        const notificationCallback = vi.mocked(channel.notification).mock
+            .calls[0][0];
+
+        const matchingNotification = {
+            type: eventType,
+            data: { message: "test" },
+        };
+        const nonMatchingNotification = {
+            type: "other-type",
+            data: { message: "test" },
+        };
+
+        notificationCallback(matchingNotification);
+        notificationCallback(nonMatchingNotification);
+
+        expect(mockCallback).toHaveBeenCalledWith(matchingNotification);
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+        expect(mockCallback).not.toHaveBeenCalledWith(nonMatchingNotification);
+    });
+
+    it("handles multiple notification event types", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+        const events = ["type1", "type2"];
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            events,
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+
+        const notificationCallback = vi.mocked(channel.notification).mock
+            .calls[0][0];
+
+        const notification1 = { type: events[0], data: {} };
+        const notification2 = { type: events[1], data: {} };
+        const notification3 = { type: "type3", data: {} };
+
+        notificationCallback(notification1);
+        notificationCallback(notification2);
+        notificationCallback(notification3);
+
+        expect(mockCallback).toHaveBeenCalledWith(notification1);
+        expect(mockCallback).toHaveBeenCalledWith(notification2);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+        expect(mockCallback).not.toHaveBeenCalledWith(notification3);
+    });
+
+    it("accepts all notifications when no event types specified", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalled();
+
+        const notificationCallback = vi.mocked(channel.notification).mock
+            .calls[0][0];
+
+        const notification1 = { type: "type1", data: {} };
+        const notification2 = { type: "type2", data: {} };
+
+        notificationCallback(notification1);
+        notificationCallback(notification2);
+
+        expect(mockCallback).toHaveBeenCalledWith(notification1);
+        expect(mockCallback).toHaveBeenCalledWith(notification2);
+        expect(mockCallback).toHaveBeenCalledTimes(2);
+    });
+
+    it("cleans up subscriptions on unmount", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        expect(echoInstance.private).toHaveBeenCalledWith(channelName);
+
+        wrapper.unmount();
+
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `private-${channelName}`,
+        );
+    });
+
+    it("won't subscribe multiple times to the same channel", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        const wrapper2 = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        expect(echoInstance.private).toHaveBeenCalledTimes(1);
+
+        wrapper.unmount();
+        expect(echoInstance.leaveChannel).not.toHaveBeenCalled();
+
+        wrapper2.unmount();
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `private-${channelName}`,
+        );
+    });
+
+    it("can leave a channel", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        wrapper.vm.leaveChannel();
+
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `private-${channelName}`,
+        );
+    });
+
+    it("can leave all channel variations", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        wrapper.vm.leave();
+
+        expect(echoInstance.leave).toHaveBeenCalledWith(channelName);
+    });
+
+    it("can manually start and stop listening", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        const channel = echoInstance.private(channelName);
+        expect(channel.notification).toHaveBeenCalledTimes(1);
+
+        wrapper.vm.stopListening();
+        wrapper.vm.listen();
+
+        expect(channel.notification).toHaveBeenCalledTimes(1);
+    });
+
+    it("stopListening prevents new notification listeners", async () => {
+        const mockCallback = vi.fn();
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            mockCallback,
+            undefined,
+        );
+
+        wrapper.vm.stopListening();
+
+        expect(wrapper.vm.stopListening).toBeDefined();
+        expect(typeof wrapper.vm.stopListening).toBe("function");
+    });
+
+    it("callback and events are optional", async () => {
+        const channelName = "test-channel";
+
+        wrapper = getNotificationTestComponent(
+            channelName,
+            undefined,
+            undefined,
+        );
 
         expect(wrapper.vm.channel).not.toBeNull();
     });


### PR DESCRIPTION
This PR addresses some of the valid clunkiness in listening for broadcast notifications noted in https://github.com/laravel/echo/issues/440 with a new `useEchoNotification` hook for both React and Vue:

```tsx
import { useEchoNotification } from '@laravel/echo-react';

// Listen to all events
useEchoNotification('App.Models.User.1', (event) => {});

// Listen to specific events
useEchoNotification('App.Models.User.1', (event) => {}, [
    'App.Notifications.InvoicePaid', 
    'App.Notifications.OrderShipped',
]);
```
