### PR TITLE
Fix subscriptions not being restored on reconnect

### DIFF
--- a/packages/laravel-echo/src/connector/socketio-connector.ts
+++ b/packages/laravel-echo/src/connector/socketio-connector.ts
@@ -46,7 +46,7 @@ export class SocketIoConnector extends Connector<
             this.options as Partial<ManagerOptions & SocketOptions>,
         );
 
-        this.socket.on("reconnect", () => {
+        this.socket.io.on("reconnect", () => {
             Object.values(this.channels).forEach((channel) => {
                 channel.subscribe();
             });


### PR DESCRIPTION
Starting from Socket IO 3.x connection state events are triggered only by socket manager

[Socket.IO documentation](https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#the-socket-instance-will-no-longer-forward-the-events-emitted-by-its-manager) | [archived](https://web.archive.org/web/20250602195218/https://socket.io/docs/v4/migrating-from-2-x-to-3-0/#the-socket-instance-will-no-longer-forward-the-events-emitted-by-its-manager)
