### PR TITLE
feat(vue): allow checking if echo is configured

### DIFF
--- a/packages/react/src/config/index.ts
+++ b/packages/react/src/config/index.ts
@@ -82,3 +82,5 @@ export const configureEcho = <T extends BroadcastDriver>(
 
 export const echo = <T extends BroadcastDriver>(): Echo<T> =>
     getEchoInstance<T>();
+
+export const echoIsConfigured = () => echoConfig !== null;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,4 +1,4 @@
-export { configureEcho, echo } from "./config/index";
+export { configureEcho, echo, echoIsConfigured } from "./config/index";
 export {
     useEcho,
     useEchoModel,

--- a/packages/react/tests/config.test.ts
+++ b/packages/react/tests/config.test.ts
@@ -1,21 +1,38 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { configureEcho, echo } from "../src";
 
-describe("echo helper", async () => {
+describe("echo helper", () => {
     beforeEach(() => {
         vi.resetModules();
     });
 
     it("throws error when Echo is not configured", async () => {
+        const { echo } = await import("../src/config");
+
         expect(() => echo()).toThrow("Echo has not been configured");
     });
 
     it("creates Echo instance with proper configuration", async () => {
+        const { configureEcho, echo } = await import("../src/config");
+
         configureEcho({
             broadcaster: "null",
         });
 
         expect(echo()).toBeDefined();
         expect(echo().options.broadcaster).toBe("null");
+    });
+
+    it("checks if Echo is configured", async () => {
+        const { configureEcho, echoIsConfigured } = await import(
+            "../src/config"
+        );
+
+        expect(echoIsConfigured()).toBe(false);
+
+        configureEcho({
+            broadcaster: "null",
+        });
+
+        expect(echoIsConfigured()).toBe(true);
     });
 });

--- a/packages/vue/src/config/index.ts
+++ b/packages/vue/src/config/index.ts
@@ -23,6 +23,8 @@ const getEchoInstance = <T extends BroadcastDriver>(): Echo<T> => {
     return echoInstance as Echo<T>;
 };
 
+export const isEchoConfigured = () => echoConfig !== null;
+
 /**
  * Configure the Echo instance with sensible defaults.
  *

--- a/packages/vue/src/config/index.ts
+++ b/packages/vue/src/config/index.ts
@@ -23,7 +23,7 @@ const getEchoInstance = <T extends BroadcastDriver>(): Echo<T> => {
     return echoInstance as Echo<T>;
 };
 
-export const isEchoConfigured = () => echoConfig !== null;
+export const echoIsConfigured = () => echoConfig !== null;
 
 /**
  * Configure the Echo instance with sensible defaults.

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,4 +5,4 @@ export {
     useEchoPresence,
     useEchoPublic,
 } from "./composables/useEcho";
-export { configureEcho, echo } from "./config/index";
+export { configureEcho, echo, isEchoConfigured } from "./config/index";

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -5,4 +5,4 @@ export {
     useEchoPresence,
     useEchoPublic,
 } from "./composables/useEcho";
-export { configureEcho, echo, isEchoConfigured } from "./config/index";
+export { configureEcho, echo, echoIsConfigured } from "./config/index";

--- a/packages/vue/tests/config.test.ts
+++ b/packages/vue/tests/config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { configureEcho, echo } from "../src/config";
+
 
 describe("echo helper", async () => {
     beforeEach(() => {
@@ -11,14 +11,30 @@ describe("echo helper", async () => {
     });
 
     it("throws error when Echo is not configured", async () => {
+        const { echo } = await import("../src/config");
+
         expect(() => echo()).toThrow("Echo has not been configured");
     });
 
     it("creates Echo instance with proper configuration", async () => {
+        const { configureEcho, echo } = await import("../src/config");
+
         configureEcho({
             broadcaster: "null",
         });
 
         expect(echo()).toBeDefined();
+    });
+
+    it("checks if Echo is configured", async () => {
+        const { configureEcho, isEchoConfigured } = await import("../src/config");
+
+        expect(isEchoConfigured()).toBe(false);
+
+        configureEcho({
+            broadcaster: "null",
+        });
+
+        expect(isEchoConfigured()).toBe(true);
     });
 });

--- a/packages/vue/tests/config.test.ts
+++ b/packages/vue/tests/config.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-
 describe("echo helper", async () => {
     beforeEach(() => {
         vi.resetModules();
@@ -27,14 +26,15 @@ describe("echo helper", async () => {
     });
 
     it("checks if Echo is configured", async () => {
-        const { configureEcho, isEchoConfigured } = await import("../src/config");
+        const { configureEcho, echoIsConfigured: echoIsConfigured } =
+            await import("../src/config");
 
-        expect(isEchoConfigured()).toBe(false);
+        expect(echoIsConfigured()).toBe(false);
 
         configureEcho({
             broadcaster: "null",
         });
 
-        expect(isEchoConfigured()).toBe(true);
+        expect(echoIsConfigured()).toBe(true);
     });
 });


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR adds a simple additional helper function to the Vue integration of Laravel Echo. This is a useful addition for cases where you might want echo to be an optional addition to an app. This allows you to check if the application configured echo, so you can listen to events elsewhere in the application, without having to handle the exception that `useEcho` or `echo` will throw when unconfigured.

Example:
```
if (import.meta.client && isEchoConfigured()) {
  useEcho(...)
}
```

Prior to this change you have to either handle the configuration state check yourself or catch the error.
