### PR TITLE
Add callback to memorize leave function.

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -127,6 +127,10 @@ export const useEcho = <
         leaveChannel(channel, leaveAll);
     }, dependencies);
 
+    const leave = useCallback(() => {
+        tearDown(true);
+    }, dependencies);
+
     useEffect(() => {
         if (initialized.current) {
             subscription.current = resolveChannelSubscription<TDriver>(channel);
@@ -147,7 +151,7 @@ export const useEcho = <
         /**
          * Leave the channel and also its associated private and presence channels
          */
-        leave: () => tearDown(true),
+        leave,
         /**
          * Stop listening for event(s) without leaving the channel
          */


### PR DESCRIPTION
### Description

This PR memoizes the `leave` callback in the `useEcho` hook using `useCallback` to prevent unnecessary re-renders and improve performance when the function is passed to child components or used in dependency arrays.

### Example: Avoiding Unnecessary Re-renders

With the previous implementation, using `leave` in a `useEffect` dependency array would cause the effect to run on every render because a new function reference was created each time:

```tsx
function MyComponent() {
  const { leave } = useEcho('my-channel', 'event', callback, []);
  
  useEffect(() => {
    // Cleanup handler that uses leave
    return () => {
      leave(); // This effect runs on EVERY render because leave is a new function each time
    };
  }, [leave]); // ❌ leave reference changes every render
  
  return <div>My Component</div>;
}
```

With this PR, the memoized `leave` function maintains a stable reference (unless dependencies change), preventing unnecessary effect re-runs:

```tsx
function MyComponent() {
  const { leave } = useEcho('my-channel', 'event', callback, []);
  
  useEffect(() => {
    // Cleanup handler that uses leave
    return () => {
      leave(); // Effect only runs when dependencies actually change
    };
  }, [leave]); // ✅ leave reference is stable
  
  return <div>My Component</div>;
}
```
