### PR TITLE
feat: add broadcaster type inference to constructor

### DIFF
--- a/packages/laravel-echo/src/echo.ts
+++ b/packages/laravel-echo/src/echo.ts
@@ -287,7 +287,7 @@ export type Broadcaster = {
         encrypted: PusherEncryptedPrivateChannel<"reverb">;
         presence: PusherPresenceChannel<"reverb">;
         options: GenericOptions<"reverb"> &
-        Partial<CustomOmit<PusherOptions<"reverb">, "cluster">>;
+            Partial<CustomOmit<PusherOptions<"reverb">, "cluster">>;
     };
     pusher: {
         connector: PusherConnector<"pusher">;
@@ -340,8 +340,8 @@ type GenericOptions<TBroadcaster extends keyof Broadcaster> = {
      * The broadcast connector.
      */
     broadcaster: TBroadcaster extends "function"
-    ? Constructor<InstanceType<Broadcaster[TBroadcaster]["connector"]>>
-    : TBroadcaster;
+        ? Constructor<InstanceType<Broadcaster[TBroadcaster]["connector"]>>
+        : TBroadcaster;
 
     auth?: {
         headers: Record<string, string>;

--- a/packages/laravel-echo/src/echo.ts
+++ b/packages/laravel-echo/src/echo.ts
@@ -40,7 +40,7 @@ export default class Echo<T extends keyof Broadcaster> {
     /**
      * Create a new class instance.
      */
-    constructor(options: EchoOptions<T>) {
+    constructor(options: EchoOptions<T> & { broadcaster: T }) {
         this.options = options;
         this.connect();
 
@@ -287,7 +287,7 @@ export type Broadcaster = {
         encrypted: PusherEncryptedPrivateChannel<"reverb">;
         presence: PusherPresenceChannel<"reverb">;
         options: GenericOptions<"reverb"> &
-            Partial<CustomOmit<PusherOptions<"reverb">, "cluster">>;
+        Partial<CustomOmit<PusherOptions<"reverb">, "cluster">>;
     };
     pusher: {
         connector: PusherConnector<"pusher">;
@@ -340,8 +340,8 @@ type GenericOptions<TBroadcaster extends keyof Broadcaster> = {
      * The broadcast connector.
      */
     broadcaster: TBroadcaster extends "function"
-        ? Constructor<InstanceType<Broadcaster[TBroadcaster]["connector"]>>
-        : TBroadcaster;
+    ? Constructor<InstanceType<Broadcaster[TBroadcaster]["connector"]>>
+    : TBroadcaster;
 
     auth?: {
         headers: Record<string, string>;


### PR DESCRIPTION
By explicitly intersecting the `EchoOptions<T>` type with `{ broadcaster: T }`, we make the broadcaster field the source of truth for generic parameter T.

Previously, when only using `EchoOptions<T>` TypeScript couldn’t reliably infer T from the value of options.broadcaster.
This meant you either had to manually specify the type parameter (`new Echo<"pusher">({...})`) or you’d lose precise typing for the connector and channel methods.

```tsx
// ✅ Type is automatically inferred from broadcaster
const echo1 = new Echo({
    broadcaster: "pusher",
    key: "my-key"
});
// Type: Echo<"pusher">
// echo1.connector is PusherConnector<"pusher">

const echo2 = new Echo({
    broadcaster: "socket.io"
});
// Type: Echo<"socket.io">
// echo2.connector is SocketIoConnector

// Channel methods are also correctly typed (this would previously be `any`):
const channel1 = echo1.channel("my-channel");
// Type: PusherChannel<"pusher">

const channel2 = echo2.channel("my-channel");
// Type: SocketIoChannel
