### PR TITLE
Events overloading

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -7,6 +7,8 @@ import type {
     ChannelData,
     ChannelReturnType,
     Connection,
+    EventName,
+    InferEventPayload,
     ModelEvents,
     ModelPayload,
 } from "../types";
@@ -69,7 +71,65 @@ const resolveChannelSubscription = <T extends BroadcastDriver>(
     return channelSubscription;
 };
 
-export const useEcho = <
+// Overload for automatic type inference from event name
+export function useEcho<
+    TEvent extends EventName = EventName,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: TEvent,
+    callback: (payload: InferEventPayload<TEvent>) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Overload for multiple events with automatic type inference
+export function useEcho<
+    TEvent extends EventName = EventName,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: TEvent[],
+    callback: (payload: InferEventPayload<TEvent>) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Overload for explicit payload type (backward compatibility)
+export function useEcho<
+    TPayload,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: string | string[],
+    callback: (payload: TPayload) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Implementation
+export function useEcho<
     TPayload,
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
@@ -79,7 +139,7 @@ export const useEcho = <
     callback: (payload: TPayload) => void = () => {},
     dependencies: any[] = [],
     visibility: TVisibility = "private" as TVisibility,
-) => {
+) {
     const channel: Channel = {
         name: channelName,
         id: ["private", "presence"].includes(visibility)
@@ -166,7 +226,7 @@ export const useEcho = <
         channel: () =>
             subscription.current as ChannelReturnType<TDriver, TVisibility>,
     };
-};
+}
 
 export const useEchoNotification = <
     TPayload,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -67,3 +67,51 @@ type ModelEvent =
 export type ModelEvents<T extends string> =
     | `.${ModelName<T>}${ModelEvent}`
     | `${ModelName<T>}${ModelEvent}`;
+
+/**
+ * Global Events interface for type inference
+ * Users can extend this in their .d.ts files to define event payload types
+ *
+ * @example
+ * // In user's types/echo.d.ts file (simplest approach):
+ * interface Events {
+ *   OrganizationUpdated: {
+ *     id: number;
+ *     name: string;
+ *     updated_at: string;
+ *   };
+ *   UserCreated: {
+ *     id: number;
+ *     email: string;
+ *     name: string;
+ *   };
+ * }
+ *
+ * @example
+ * // Alternative: Module augmentation
+ * declare module '@laravel/echo-react' {
+ *   interface Events {
+ *     OrganizationUpdated: {
+ *       id: number;
+ *       name: string;
+ *       updated_at: string;
+ *     };
+ *   }
+ * }
+ */
+declare global {
+    interface Events {
+        // This interface is meant to be extended by users in their .d.ts files
+    }
+}
+
+/**
+ * Type alias for event names - helps with autocomplete suggestions
+ */
+export type EventName = keyof Events & string;
+
+/**
+ * Type utility to infer payload type from event name
+ */
+export type InferEventPayload<TEvent extends string> =
+    TEvent extends keyof Events ? Events[TEvent] : unknown;

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -108,6 +108,7 @@ declare global {
 /**
  * Type alias for event names - helps with autocomplete suggestions
  */
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export type EventName = keyof Events & string;
 
 /**

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -7,6 +7,7 @@ import type {
     ChannelData,
     ChannelReturnType,
     Connection,
+    EventName,
     InferEventPayload,
     ModelEvents,
     ModelPayload,
@@ -72,7 +73,7 @@ const leaveChannel = (channel: Channel, leaveAll: boolean = false): void => {
 
 // Overload for automatic type inference from event name
 export function useEcho<
-    TEvent extends keyof Events & string,
+    TEvent extends EventName = EventName,
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
 >(
@@ -91,7 +92,7 @@ export function useEcho<
 
 // Overload for multiple events with automatic type inference
 export function useEcho<
-    TEvent extends keyof Events & string,
+    TEvent extends EventName = EventName,
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
 >(

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -7,6 +7,7 @@ import type {
     ChannelData,
     ChannelReturnType,
     Connection,
+    InferEventPayload,
     ModelEvents,
     ModelPayload,
 } from "../types";
@@ -69,7 +70,65 @@ const leaveChannel = (channel: Channel, leaveAll: boolean = false): void => {
     }
 };
 
-export const useEcho = <
+// Overload for automatic type inference from event name
+export function useEcho<
+    TEvent extends keyof Events & string,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: TEvent,
+    callback: (payload: InferEventPayload<TEvent>) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Overload for multiple events with automatic type inference
+export function useEcho<
+    TEvent extends keyof Events & string,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: TEvent[],
+    callback: (payload: InferEventPayload<TEvent>) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Overload for explicit payload type (backward compatibility)
+export function useEcho<
+    TPayload,
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    event: string | string[],
+    callback: (payload: TPayload) => void,
+    dependencies?: any[],
+    visibility?: TVisibility,
+): {
+    leaveChannel: (leaveAll?: boolean) => void;
+    leave: () => void;
+    stopListening: () => void;
+    listen: () => void;
+    channel: () => ChannelReturnType<TDriver, TVisibility>;
+};
+
+// Implementation
+export function useEcho<
     TPayload,
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
@@ -79,7 +138,7 @@ export const useEcho = <
     callback: (payload: TPayload) => void = () => {},
     dependencies: any[] = [],
     visibility: TVisibility = "private" as TVisibility,
-) => {
+) {
     const eventCallback = ref(callback);
     const listening = ref(false);
 
@@ -177,7 +236,7 @@ export const useEcho = <
          */
         channel: () => subscription as ChannelReturnType<TDriver, TVisibility>,
     };
-};
+}
 
 export const useEchoNotification = <
     TPayload,

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -67,3 +67,46 @@ type ModelEvent =
 export type ModelEvents<T extends string> =
     | `.${ModelName<T>}${ModelEvent}`
     | `${ModelName<T>}${ModelEvent}`;
+
+/**
+ * Global Events interface for type inference
+ * Users can extend this in their .d.ts files to define event payload types
+ *
+ * @example
+ * // In user's types/echo.d.ts file (simplest approach):
+ * interface Events {
+ *   OrganizationUpdated: {
+ *     id: number;
+ *     name: string;
+ *     updated_at: string;
+ *   };
+ *   UserCreated: {
+ *     id: number;
+ *     email: string;
+ *     name: string;
+ *   };
+ * }
+ *
+ * @example
+ * // Alternative: Module augmentation
+ * declare module '@laravel/echo-vue' {
+ *   interface Events {
+ *     OrganizationUpdated: {
+ *       id: number;
+ *       name: string;
+ *       updated_at: string;
+ *     };
+ *   }
+ * }
+ */
+declare global {
+    interface Events {
+        // This interface is meant to be extended by users in their .d.ts files
+    }
+}
+
+/**
+ * Type utility to infer payload type from event name
+ */
+export type InferEventPayload<TEvent extends string> =
+    TEvent extends keyof Events ? Events[TEvent] : unknown;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -106,6 +106,11 @@ declare global {
 }
 
 /**
+ * Type alias for event names - helps with autocomplete suggestions
+ */
+export type EventName = keyof Events & string;
+
+/**
  * Type utility to infer payload type from event name
  */
 export type InferEventPayload<TEvent extends string> =

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -108,6 +108,7 @@ declare global {
 /**
  * Type alias for event names - helps with autocomplete suggestions
  */
+// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
 export type EventName = keyof Events & string;
 
 /**


### PR DESCRIPTION
This PR adds optional event/payload overloading. This allows the user to create, for example, an `echo-broadcast-events.d.ts` file such as this:

```ts
declare module "@laravel/echo-react" {
    interface Events {
        ".App.Events.PodcastProcessed": {
            user: {
                id: number;
                name: string;
                email: string;
            };
        };
    }
}
```

This provides automatic autocompletion for event names in hooks with the correlating payload typing for free.