### PR TITLE
fix: prevent isConstructor from executing constructor side effects

### DIFF
--- a/packages/laravel-echo/src/util/index.ts
+++ b/packages/laravel-echo/src/util/index.ts
@@ -1,9 +1,6 @@
 function isConstructor(obj: unknown): obj is new (...args: any[]) => any {
     try {
-        // Use Reflect.construct with a dummy target to check if obj
-        // can serve as a constructor without actually executing its
-        // constructor body. This avoids side effects (e.g. network
-        // requests) that occur when instantiating connector classes.
+        // Avoid side effects when instantiating connector classes...
         Reflect.construct(String, [], obj as new (...args: any[]) => any);
         return true;
     } catch {

--- a/packages/laravel-echo/src/util/index.ts
+++ b/packages/laravel-echo/src/util/index.ts
@@ -1,16 +1,14 @@
 function isConstructor(obj: unknown): obj is new (...args: any[]) => any {
     try {
-        new (obj as new (...args: any[]) => any)();
-    } catch (err) {
-        if (
-            err instanceof Error &&
-            err.message.includes("is not a constructor")
-        ) {
-            return false;
-        }
+        // Use Reflect.construct with a dummy target to check if obj
+        // can serve as a constructor without actually executing its
+        // constructor body. This avoids side effects (e.g. network
+        // requests) that occur when instantiating connector classes.
+        Reflect.construct(String, [], obj as new (...args: any[]) => any);
+        return true;
+    } catch {
+        return false;
     }
-
-    return true;
 }
 
 export { isConstructor };

--- a/packages/laravel-echo/tests/util/is-constructor.test.ts
+++ b/packages/laravel-echo/tests/util/is-constructor.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test, vi } from "vitest";
+import { isConstructor } from "../../src/util";
+
+describe("isConstructor", () => {
+    test("it returns true for a class", () => {
+        class MyClass {}
+        expect(isConstructor(MyClass)).toBe(true);
+    });
+
+    test("it returns true for a regular function", () => {
+        function MyFunction() {}
+        expect(isConstructor(MyFunction)).toBe(true);
+    });
+
+    test("it returns false for an arrow function", () => {
+        const arrow = () => {};
+        expect(isConstructor(arrow)).toBe(false);
+    });
+
+    test("it returns false for a non-function value", () => {
+        expect(isConstructor("string")).toBe(false);
+        expect(isConstructor(42)).toBe(false);
+        expect(isConstructor(null)).toBe(false);
+        expect(isConstructor(undefined)).toBe(false);
+        expect(isConstructor({})).toBe(false);
+    });
+
+    test("it does not execute the constructor body", () => {
+        const sideEffect = vi.fn();
+
+        class SideEffectClass {
+            constructor() {
+                sideEffect();
+            }
+        }
+
+        isConstructor(SideEffectClass);
+        expect(sideEffect).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
So this error popped up when using a third-party connector. I believe this connector may have some issues of its own, but fixing the issue at laravel-echo's level seems to be the more robust long-term solution.

The `isConstructor` utility used in `Echo.connect()` verifies that a custom `broadcaster` value is a constructor before instantiating it. The current implementation does this by calling `new obj()` without any arguments.

This causes unintended side effects when the broadcaster is a connector class whose constructor triggers real work. For example, with `laravel-wave`'s `WaveConnector` (https://github.com/qruto/laravel-wave), the check triggers the full `Connector` base class chain (`setOptions` → `connect`), which opens a `fetch`-based SSE connection to the default relative endpoint `/wave`. Because no options were passed, this resolves against the page origin (e.g. `localhost:3000/wave` or `example.com/wave`) instead of the actual backend URL. The connection immediately fails with a 4xx, producing a `FatalError` in the console and a wasted HTTP request everytime the connection is opened.

### Benefit to end users

Any application using a custom broadcaster whose constructor has side effects (network connections, resource allocation, etc.) currently pays the cost of a spurious instantiation on every `new Echo(...)` call. This fix eliminates that overhead and the resulting console errors/failed network requests.

### The fix

Replace `new obj()` with `Reflect.construct(String, [], obj)`. This uses `obj` as the `newTarget` parameter of `Reflect.construct`, which validates that `obj` is a valid constructor **without ever executing `obj`'s constructor body**. Only the `String` constructor runs (harmlessly), and the result is discarded.

The detection semantics remain identical:
- Classes → `true`
- Regular functions → `true`
- Arrow functions → `false`

### Why this does not break any existing features

`Reflect.construct(Target, args, newTarget)` throws a `TypeError` if and only if `newTarget` is not a valid constructor, which is exactly the same set of values that would cause `new obj()` to throw `"is not a constructor"`. The only difference is that the constructor body of `obj` is never executed. All 12 existing tests pass unchanged.

### Tests

Added `tests/util/is-constructor.test.ts` with five cases covering classes, regular functions, arrow functions, non-function values, and a regression test that asserts the constructor body is never invoked during the check.
