### PR TITLE
fix: useEchoNotification callback not firing after re-render

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -281,7 +281,6 @@ export const useEchoNotification = <
     }, [eventKey]);
 
     const listening = useRef(false);
-    const initializedRef = useRef(false);
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const memoizedCallback = useCallback(callback, dependencies);
@@ -304,12 +303,9 @@ export const useEchoNotification = <
             return;
         }
 
-        if (!initializedRef.current) {
-            result.channel().notification(cb);
-        }
+        result.channel().notification(cb);
 
         listening.current = true;
-        initializedRef.current = true;
     }, [cb, result]);
 
     const stopListening = useCallback(() => {

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -1222,8 +1222,8 @@ describe("useEchoNotification hook", async () => {
 
         result.current.listen();
 
-        // notification should still only be called once due to initialized check
-        expect(channel.notification).toHaveBeenCalledTimes(1);
+        // notification should be re-registered after stop + listen
+        expect(channel.notification).toHaveBeenCalledTimes(2);
     });
 
     it("stopListening prevents new notification listeners", async () => {

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -267,7 +267,6 @@ export const useEchoNotification = <
         .flat();
 
     const listening = ref(false);
-    const initialized = ref(false);
 
     const cb = (notification: BroadcastNotification<TPayload>) => {
         if (!listening.value) {
@@ -284,12 +283,9 @@ export const useEchoNotification = <
             return;
         }
 
-        if (!initialized.value) {
-            result.channel().notification(cb);
-        }
+        result.channel().notification(cb);
 
         listening.value = true;
-        initialized.value = true;
     };
 
     const stopListening = () => {

--- a/packages/vue/tests/useEcho.test.ts
+++ b/packages/vue/tests/useEcho.test.ts
@@ -1011,7 +1011,7 @@ describe("useEchoNotification hook", async () => {
         wrapper.vm.stopListening();
         wrapper.vm.listen();
 
-        expect(channel.notification).toHaveBeenCalledTimes(1);
+        expect(channel.notification).toHaveBeenCalledTimes(2);
     });
 
     it("stopListening prevents new notification listeners", async () => {


### PR DESCRIPTION
Fixes #467

## The problem

`useEchoNotification` stops working after a re-render because the notification listener is never re-registered.

Both the React and Vue hooks had an `initialized` flag that was meant to prevent double-registration, but it also prevented *re*-registration after cleanup. Here's what happens:

```ts
// 1. First mount — works fine
listen()
  → listening = false, initialized = false
  → calls channel.notification(cb) ✅
  → sets listening = true, initialized = true

// 2. Callback changes (re-render) → effect cleanup runs
stopListening()
  → calls channel.stopListeningForNotification(cb)
  → sets listening = false
  // but initialized is still true!

// 3. Effect re-runs
listen()
  → listening = false ✓ (passes the guard)
  → initialized = true ✗ (skips notification registration!)
  → listener is gone forever
```

This means any component re-render that changes the callback reference will silently kill the notification listener. It also affects the manual `stopListening()` / `listen()` cycle shown in #467.

## The fix

Remove the `initialized` guard entirely. The `listening` flag already prevents double-registration — if `listening` is `true`, `listen()` is a no-op. After `stopListening()` sets it back to `false`, `listen()` correctly re-registers the notification callback.

This matches how the base `useEcho` hook already works — it only uses a `listening` guard, no separate `initialized` flag.

## Test plan

- [x] Updated existing "can manually start and stop listening" tests in both React and Vue to assert that `notification()` is called again after a stop/listen cycle
- [x] All existing tests pass (`pnpm test`)