### PR TITLE
Refactor useConnectionStatus

### DIFF
--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -380,12 +380,15 @@ export const useEchoModel = <
  * @returns Ref<ConnectionStatus> - A reactive ref containing the current connection status
  */
 export const useConnectionStatus = (): Ref<ConnectionStatus> => {
-    const status = ref<ConnectionStatus>(echo().connectionStatus());
+    const echoInstance = echo();
+    const status = ref<ConnectionStatus>(echoInstance.connectionStatus());
 
     let unsubscribe: (() => void) | undefined;
 
     onMounted(() => {
-        unsubscribe = echo().connector.onConnectionChange((newStatus) => {
+        status.value = echoInstance.connectionStatus();
+
+        unsubscribe = echoInstance.connector.onConnectionChange((newStatus) => {
             status.value = newStatus;
         });
     });


### PR DESCRIPTION
Even though `const status = ref<ConnectionStatus>(echo().connectionStatus())` exists, the connection is not correctly set on mounted.

This PR sets the status on mounted as well. Used a single echo instance while it.