### PR TITLE
Support listener context on Pusher subscriptions

### DIFF
--- a/packages/laravel-echo/package.json
+++ b/packages/laravel-echo/package.json
@@ -40,6 +40,7 @@
         "@babel/preset-env": "^7.26.7",
         "@types/jquery": "^3.5.32",
         "@types/node": "^20.0.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.21.0",
         "@typescript-eslint/parser": "^8.21.0",
         "axios": "^1.15.0",
@@ -51,7 +52,8 @@
         "typescript": "^5.7.0",
         "vite": "^6.4.2",
         "vite-plugin-dts": "^4.5.3",
-        "vitest": "^3.1.2"
+        "vitest": "^3.1.2",
+        "ws": "^8.20.0"
     },
     "peerDependencies": {
         "pusher-js": "*",

--- a/packages/laravel-echo/src/channel/pusher-channel.ts
+++ b/packages/laravel-echo/src/channel/pusher-channel.ts
@@ -66,8 +66,8 @@ export class PusherChannel<
     /**
      * Listen for an event on the channel instance.
      */
-    listen(event: string, callback: CallableFunction): this {
-        this.on(this.eventFormatter.format(event), callback);
+    listen(event: string, callback: CallableFunction, context?: any): this {
+        this.on(this.eventFormatter.format(event), callback, context);
 
         return this;
     }
@@ -113,6 +113,15 @@ export class PusherChannel<
     }
 
     /**
+     * Remove handlers for the given context
+     */
+    stopListeningForContext(context: any): this {
+        this.subscription.unbind(undefined, undefined, context);
+
+        return this;
+    }
+
+    /**
      * Stop listening for all events on the channel instance.
      */
     stopListeningToAll(callback?: CallableFunction): this {
@@ -128,10 +137,10 @@ export class PusherChannel<
     /**
      * Register a callback to be called anytime a subscription succeeds.
      */
-    subscribed(callback: CallableFunction): this {
+    subscribed(callback: CallableFunction, context?: any): this {
         this.on("pusher:subscription_succeeded", () => {
             callback();
-        });
+        }, context);
 
         return this;
     }
@@ -139,10 +148,10 @@ export class PusherChannel<
     /**
      * Register a callback to be called anytime a subscription error occurs.
      */
-    error(callback: CallableFunction): this {
+    error(callback: CallableFunction, context?: any): this {
         this.on("pusher:subscription_error", (status: Record<string, any>) => {
             callback(status);
-        });
+        }, context);
 
         return this;
     }
@@ -150,8 +159,8 @@ export class PusherChannel<
     /**
      * Bind a channel to an event.
      */
-    on(event: string, callback: CallableFunction): this {
-        this.subscription.bind(event, callback);
+    on(event: string, callback: CallableFunction, context?: any): this {
+        this.subscription.bind(event, callback, context);
 
         return this;
     }

--- a/packages/laravel-echo/src/connector/pusher-connector.ts
+++ b/packages/laravel-echo/src/connector/pusher-connector.ts
@@ -81,8 +81,9 @@ export class PusherConnector<
         name: string,
         event: string,
         callback: CallableFunction,
+        context?: any
     ): AnyPusherChannel {
-        return this.channel(name).listen(event, callback);
+        return this.channel(name).listen(event, callback, context);
     }
 
     /**

--- a/packages/laravel-echo/tests/channel/pusher-channel.test.ts
+++ b/packages/laravel-echo/tests/channel/pusher-channel.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import Pusher from "pusher-js";
+import { AddressInfo, WebSocketServer } from 'ws';
+import { PusherConnector } from "../../src/connector";
+
+describe("PusherChannel", () => {
+    let wss: WebSocketServer;
+    let connector: PusherConnector<'null'>;
+    
+    beforeEach(() => {
+        wss = new WebSocketServer({ port: 0 });
+
+        const { port } = wss.address() as AddressInfo;
+
+        const pusher = new Pusher('test-key', {
+            wsHost: '127.0.0.1',
+            wsPort: port,
+            forceTLS: false,
+            enabledTransports: ['ws'],
+            disableStats: true,
+            cluster: 'test'
+        });
+
+        connector = new PusherConnector({
+            client: pusher,
+            broadcaster: "null",
+            namespace: false
+        });
+    });
+
+    afterEach(async () => {
+        await new Promise<void>((resolve) => wss.close(() => resolve()));
+    });
+
+    test("can remove channel listeners by context", () => {
+        const channel = connector.channel("some.name");
+
+        const l1 = vi.fn();
+        const l2 = vi.fn();
+        const l3 = vi.fn();
+        const l4 = vi.fn();
+        const context = "foobar";
+
+        channel.listen("MyEvent", l1, context);
+        connector.listen("some.name", "MyEvent", l2, context);
+        channel.listen("MyEvent", l3);
+        connector.listen("some.name", "MyEvent", l4);
+
+        channel.stopListeningForContext(context);
+
+        channel.subscription.emit("MyEvent", {});
+
+        expect(l1).not.toHaveBeenCalled();
+        expect(l2).not.toHaveBeenCalled();
+        expect(l3).toHaveBeenCalled();
+        expect(l4).toHaveBeenCalled();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.17.32
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.21.0
         version: 8.31.1(@typescript-eslint/parser@8.31.1(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)
@@ -84,6 +87,9 @@ importers:
       vitest:
         specifier: ^3.1.2
         version: 3.1.2(@types/node@20.17.32)(jsdom@26.1.0)
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
 
   packages/react:
     devDependencies:
@@ -1421,66 +1427,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1644,6 +1663,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.31.1':
     resolution: {integrity: sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==}
@@ -3357,6 +3379,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -4764,6 +4798,10 @@ snapshots:
   '@types/sizzle@2.3.9': {}
 
   '@types/trusted-types@2.0.7': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.3
 
   '@typescript-eslint/eslint-plugin@8.31.1(@typescript-eslint/parser@8.31.1(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)':
     dependencies:
@@ -6801,6 +6839,8 @@ snapshots:
   ws@8.17.1: {}
 
   ws@8.18.1: {}
+
+  ws@8.20.0: {}
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
Pusher has the ability to add context as the third argument when binding and unbinding callbacks, which conveniently lets me remove multiple bound callbacks at once using `channel.unbind(undefined, undefined, context)`. This PR adds support for context when using Pusher channels, and adds a method `stopListeningForContext` to remove all listeners for the given context.

I've also added a `PusherChannel` test for this feature. In order to properly test `PusherChannel`, the test starts a bare-bones WebSocketServer with the `ws` library. I'm no expert on frontend testing, so feel free to clean it up as you see fit.