### PR TITLE
Mark pusher-js and socket.io-client as optional peerDependencies

### DIFF
--- a/packages/laravel-echo/package.json
+++ b/packages/laravel-echo/package.json
@@ -57,6 +57,14 @@
         "pusher-js": "*",
         "socket.io-client": "*"
     },
+    "peerDependenciesMeta": {
+        "pusher-js": {
+            "optional": true
+        },
+        "socket.io-client": {
+            "optional": true
+        }
+    },
     "typesVersions": {
         "*": {
             "socket.io-client": [],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -68,6 +68,14 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "socket.io-client": "*"
     },
+    "peerDependenciesMeta": {
+        "pusher-js": {
+            "optional": true
+        },
+        "socket.io-client": {
+            "optional": true
+        }
+    },
     "typesVersions": {
         "*": {
             "socket.io-client": [],

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -61,6 +61,14 @@
         "socket.io-client": "*",
         "svelte": "^5.0.0"
     },
+    "peerDependenciesMeta": {
+        "pusher-js": {
+            "optional": true
+        },
+        "socket.io-client": {
+            "optional": true
+        }
+    },
     "typesVersions": {
         "*": {
             "socket.io-client": [],

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,6 +60,14 @@
         "socket.io-client": "*",
         "vue": "^3.0.0"
     },
+    "peerDependenciesMeta": {
+        "pusher-js": {
+            "optional": true
+        },
+        "socket.io-client": {
+            "optional": true
+        }
+    },
     "typesVersions": {
         "*": {
             "socket.io-client": [],


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Should resolve #473.


Looks like some package managers automatically install peer dependencies.
This causes audit warnings even if, for example socket.io is not actually used.
Marking pusher-js and socket.io-client as optional in peerDependenciesMeta fixes this. Neither is installed unless explicitly declared. 

I don't think this causes any breaking changes.

To quote the [npmjs docs](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#peerdependenciesmeta) that seem to confirm this: 
> The peerDependenciesMeta field serves to provide npm more information on how your peer dependencies are to be used. Specifically, it allows peer dependencies to be marked as optional. Npm will not automatically install optional peer dependencies. This allows you to integrate and interact with a variety of host packages without requiring all of them to be installed.

Applied  these changes to each package.