### PR TITLE
Add StrictMode regression tests for useEchoNotification (#482)

### DIFF
--- a/packages/react/tests/use-echo-strict-mode.test.ts
+++ b/packages/react/tests/use-echo-strict-mode.test.ts
@@ -1,0 +1,116 @@
+import { act, renderHook } from "@testing-library/react";
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getEchoModule = async () => import("../src/hooks/use-echo");
+const getConfigModule = async () => import("../src/config/index");
+
+// Regression tests for https://github.com/laravel/echo/issues/482: in
+// StrictMode, React mounts, cleans up, and remounts effects. The mock tracks
+// real bind/unbind semantics so we can tell whether a notification
+// listener is actually bound after StrictMode's mount -> cleanup -> remount.
+vi.mock("laravel-echo", () => {
+    const notificationListeners = new Set<(payload: unknown) => void>();
+    const eventListeners = new Map<string, Set<(payload: unknown) => void>>();
+
+    const mockPrivateChannel = {
+        leaveChannel: vi.fn(),
+        listen: vi.fn((event: string, cb: (payload: unknown) => void) => {
+            if (!eventListeners.has(event)) {
+                eventListeners.set(event, new Set());
+            }
+            eventListeners.get(event)!.add(cb);
+        }),
+        stopListening: vi.fn(
+            (event: string, cb: (payload: unknown) => void) => {
+                eventListeners.get(event)?.delete(cb);
+            },
+        ),
+        notification: vi.fn((cb: (payload: unknown) => void) => {
+            notificationListeners.add(cb);
+        }),
+        stopListeningForNotification: vi.fn(
+            (cb: (payload: unknown) => void) => {
+                notificationListeners.delete(cb);
+            },
+        ),
+    };
+
+    const Echo = vi.fn() as ReturnType<typeof vi.fn> & {
+        __notificationListeners: typeof notificationListeners;
+        __eventListeners: typeof eventListeners;
+    };
+
+    Echo.prototype.private = vi.fn(() => mockPrivateChannel);
+    Echo.prototype.channel = vi.fn(() => mockPrivateChannel);
+    Echo.prototype.join = vi.fn(() => mockPrivateChannel);
+    Echo.prototype.leave = vi.fn();
+    Echo.prototype.leaveChannel = vi.fn();
+    Echo.prototype.connectionStatus = vi.fn(() => "connected");
+    Echo.prototype.socketId = vi.fn(() => undefined);
+    Echo.prototype.connector = { onConnectionChange: vi.fn(() => () => {}) };
+
+    Echo.__notificationListeners = notificationListeners;
+    Echo.__eventListeners = eventListeners;
+
+    return { default: Echo };
+});
+
+describe("hooks under React.StrictMode", () => {
+    beforeEach(async () => {
+        vi.resetModules();
+
+        const configModule = await getConfigModule();
+        configModule.configureEcho({ broadcaster: "null" });
+    });
+
+    it("useEchoNotification invokes the callback after StrictMode remount", async () => {
+        const echoModule = await getEchoModule();
+        const EchoMock = (await import("laravel-echo")).default as unknown as {
+            __notificationListeners: Set<(payload: unknown) => void>;
+        };
+
+        const mockCallback = vi.fn();
+
+        renderHook(
+            () =>
+                echoModule.useEchoNotification("orders", mockCallback, [
+                    "OrderShipped",
+                ]),
+            { wrapper: StrictMode },
+        );
+
+        // Simulate the server broadcasting a notification: fire every listener
+        // that is still bound on the channel.
+        act(() => {
+            EchoMock.__notificationListeners.forEach((cb) =>
+                cb({ type: "OrderShipped" }),
+            );
+        });
+
+        expect(EchoMock.__notificationListeners.size).toBeGreaterThan(0);
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it("useEcho invokes the callback after StrictMode remount (control)", async () => {
+        const echoModule = await getEchoModule();
+        const EchoMock = (await import("laravel-echo")).default as unknown as {
+            __eventListeners: Map<string, Set<(payload: unknown) => void>>;
+        };
+
+        const mockCallback = vi.fn();
+
+        renderHook(
+            () => echoModule.useEcho("orders", "OrderShipped", mockCallback),
+            { wrapper: StrictMode },
+        );
+
+        act(() => {
+            EchoMock.__eventListeners
+                .get("OrderShipped")
+                ?.forEach((cb) => cb({ order: 1 }));
+        });
+
+        expect(mockCallback).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Related to #482.

While investigating #482 (`useEchoNotification` callback never invoked under `React.StrictMode`), I found the bug no longer reproduces on `2.x`:

- **v2.3.0** (the reported version): on StrictMode's mount → cleanup → remount cycle, the cleanup unbound the notification listener via `stopListeningForNotification()`, but the `initializedRef` guard in `listen()` prevented the remount from ever re-binding it — the channel ended up with no notification listener, matching the report.
- **`2.x` / v2.3.5+**: the `initializedRef` guard was removed in the channel-subscription rework, so the remount re-binds correctly and the callback fires.

Since nothing covered this, this PR adds regression tests. The mock implements real bind/unbind semantics (a `Set` of bound listeners mutated by `notification()` / `stopListeningForNotification()`), so the assertion checks what is actually still bound after the StrictMode cycle rather than just that `notification()` was called at some point:

- `useEchoNotification` still has a bound listener and invokes the callback after the StrictMode remount — **fails against the v2.3.0 implementation, passes on `2.x`** (verified by swapping in the old `use-echo.ts`).
- A `useEcho` control test covering the same cycle for regular events.

#482 itself can likely be closed — the fix has shipped, the reporter was on 2.3.0.