### PR TITLE
Replace socket.io-client imports with a local type shim in echo.d.ts

### DIFF
--- a/packages/laravel-echo/src/channel/socketio-channel.ts
+++ b/packages/laravel-echo/src/channel/socketio-channel.ts
@@ -1,6 +1,6 @@
 import { EventFormatter } from "../util";
 import { Channel } from "./channel";
-import type { Socket } from "socket.io-client";
+import type { SocketIoSocket as Socket } from "../socketio-types";
 import type { EchoOptionsWithDefaults } from "../connector";
 import type { BroadcastDriver } from "../echo";
 

--- a/packages/laravel-echo/src/connector/socketio-connector.ts
+++ b/packages/laravel-echo/src/connector/socketio-connector.ts
@@ -1,9 +1,7 @@
 import type {
-    io,
-    ManagerOptions,
-    Socket,
-    SocketOptions,
-} from "socket.io-client";
+    SocketIoFunction,
+    SocketIoSocket as Socket,
+} from "../socketio-types";
 import {
     SocketIoChannel,
     SocketIoPresenceChannel,
@@ -40,11 +38,11 @@ export class SocketIoConnector extends Connector<
      * Create a fresh Socket.io connection.
      */
     connect(): void {
-        let io = this.getSocketIO();
+        const io = this.getSocketIO();
 
         this.socket = io(
             this.options.host ?? undefined,
-            this.options as Partial<ManagerOptions & SocketOptions>,
+            this.options as Record<string, unknown>,
         );
 
         this.socket.io.on("reconnect", () => {
@@ -57,9 +55,9 @@ export class SocketIoConnector extends Connector<
     /**
      * Get socket.io module from global scope or options.
      */
-    getSocketIO(): typeof io {
+    getSocketIO(): SocketIoFunction {
         if (typeof this.options.client !== "undefined") {
-            return this.options.client as typeof io;
+            return this.options.client as SocketIoFunction;
         }
 
         if (typeof window !== "undefined" && typeof window.io !== "undefined") {

--- a/packages/laravel-echo/src/socketio-types.ts
+++ b/packages/laravel-echo/src/socketio-types.ts
@@ -1,13 +1,5 @@
 /**
  * Minimal Socket.io type shim.
- *
- * These interfaces mirror the subset of socket.io-client that Laravel Echo
- * actually uses. Declaring them locally means the compiled echo.d.ts does not
- * unconditionally import from "socket.io-client", so projects that only use
- * Reverb or Pusher no longer need that package installed.
- *
- * When socket.io-client is installed the real types satisfy these interfaces,
- * so nothing changes for Socket.io users.
  */
 
 export interface SocketIoManager {

--- a/packages/laravel-echo/src/socketio-types.ts
+++ b/packages/laravel-echo/src/socketio-types.ts
@@ -1,0 +1,33 @@
+/**
+ * Minimal Socket.io type shim.
+ *
+ * These interfaces mirror the subset of socket.io-client that Laravel Echo
+ * actually uses. Declaring them locally means the compiled echo.d.ts does not
+ * unconditionally import from "socket.io-client", so projects that only use
+ * Reverb or Pusher no longer need that package installed.
+ *
+ * When socket.io-client is installed the real types satisfy these interfaces,
+ * so nothing changes for Socket.io users.
+ */
+
+export interface SocketIoManager {
+    /** @internal */
+    _reconnecting: boolean;
+    on(event: string, callback: (...args: any[]) => void): this;
+}
+
+export interface SocketIoSocket {
+    id: string | undefined;
+    connected: boolean;
+    io: SocketIoManager;
+    on(event: string, callback: (...args: any[]) => void): this;
+    off(event: string, callback?: (...args: any[]) => void): this;
+    removeListener(event: string, callback?: (...args: any[]) => void): this;
+    emit(event: string, ...args: any[]): this;
+    disconnect(): this;
+}
+
+export type SocketIoFunction = (
+    uri?: string,
+    opts?: Record<string, unknown>,
+) => SocketIoSocket;

--- a/packages/laravel-echo/typings/window.d.ts
+++ b/packages/laravel-echo/typings/window.d.ts
@@ -1,7 +1,7 @@
 import type { AxiosStatic } from "axios";
 import type { JQueryStatic } from "jquery";
 import type Pusher from "pusher-js";
-import type { io } from "socket.io-client";
+import type { SocketIoFunction } from "../src/socketio-types";
 
 declare global {
     interface Window {
@@ -9,7 +9,7 @@ declare global {
             csrfToken?: string;
         };
 
-        io?: typeof io;
+        io?: SocketIoFunction;
         Pusher?: typeof Pusher;
 
         Vue?: any;


### PR DESCRIPTION
Since v2.3.7, the compiled `dist/echo.d.ts` unconditionally imports `Socket` and `io` from `socket.io-client`. Users who only use Reverb or Pusher never install that package, so TypeScript fails on those imports when `skipLibCheck` is `false`.

The root cause is that `socketio-channel.ts` and `socketio-connector.ts` import from `socket.io-client`, and `vite-plugin-dts` (with `rollupTypes: true`) inlines those module references into the rolled-up declaration file.

This PR adds a minimal local type shim (`src/socketio-types.ts`) that declares the small subset of Socket.io types Laravel Echo actually uses — `SocketIoSocket`, `SocketIoManager`, and `SocketIoFunction`. The two connector/channel files and `typings/window.d.ts` are updated to import from the shim instead of from `socket.io-client`. The real socket.io-client types satisfy these interfaces, so nothing changes for users who do have the package installed.

After this change, `dist/echo.d.ts` no longer contains any `import … from 'socket.io-client'` line. Verified by temporarily removing the package from `node_modules` and running `tsc --noEmit` — no errors. All existing tests still pass.

Fixes #528