### PR TITLE
Add `useChannel` hooks

### DIFF
--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -386,6 +386,82 @@ export const useEchoPublic = <
     );
 };
 
+export function useChannel<
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    visibility: TVisibility = "private" as TVisibility,
+) {
+    const channel: Channel = useMemo(
+        () => ({
+            name: channelName,
+            id: ["private", "presence"].includes(visibility)
+                ? `${visibility}-${channelName}`
+                : channelName,
+            visibility,
+        }),
+        [channelName, visibility],
+    );
+
+    const subscription = useRef<Connection<TDriver> | null>(null);
+
+    const tearDown = useCallback(
+        (leaveAll: boolean = false) => {
+            leaveChannel(channel, leaveAll);
+        },
+        [channel],
+    );
+
+    const leave = useCallback(() => {
+        tearDown(true);
+    }, [tearDown]);
+
+    useEffect(() => {
+        subscription.current = resolveChannelSubscription<TDriver>(channel);
+
+        return () => tearDown();
+    }, [tearDown, channel]);
+
+    return useMemo(
+        () => ({
+            /**
+             * Leave the channel
+             */
+            leaveChannel: tearDown,
+            /**
+             * Leave the channel and also its associated private and presence channels
+             */
+            leave,
+            /**
+             * Channel instance
+             */
+            channel: () =>
+                subscription.current as ChannelReturnType<
+                    TDriver,
+                    TVisibility
+                > | null,
+        }),
+        [leave, tearDown],
+    );
+}
+
+export const usePresenceChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: string,
+) => {
+    return useChannel<TDriver, "presence">(channelName, "presence");
+};
+
+export const usePublicChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: string,
+) => {
+    return useChannel<TDriver, "public">(channelName, "public");
+};
+
 export const useEchoModel = <
     TPayload,
     TModel extends string,

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -389,10 +389,7 @@ export const useEchoPublic = <
 export function useChannel<
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
->(
-    channelName: string,
-    visibility: TVisibility = "private" as TVisibility,
-) {
+>(channelName: string, visibility: TVisibility = "private" as TVisibility) {
     const channel: Channel = useMemo(
         () => ({
             name: channelName,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,11 +1,14 @@
 export type { ConnectionStatus } from "laravel-echo";
 export { configureEcho, echo, echoIsConfigured } from "./config/index";
 export {
+    useChannel,
     useConnectionStatus,
     useEcho,
     useEchoModel,
     useEchoNotification,
     useEchoPresence,
     useEchoPublic,
+    usePresenceChannel,
+    usePublicChannel,
     useSocketId,
 } from "./hooks/use-echo";

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,11 +1,14 @@
 export type { ConnectionStatus } from "laravel-echo";
 export { configureEcho, echo, echoIsConfigured } from "./config/index";
 export {
+    useChannel,
     useConnectionStatus,
     useEcho,
     useEchoModel,
     useEchoNotification,
     useEchoPresence,
     useEchoPublic,
+    usePresenceChannel,
+    usePublicChannel,
     useSocketId,
 } from "./runes/useEcho";

--- a/packages/svelte/src/runes/useEcho.ts
+++ b/packages/svelte/src/runes/useEcho.ts
@@ -409,6 +409,60 @@ export const useEchoPublic = <
     );
 };
 
+export function useChannel<
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: ReactiveInput<string>,
+    visibility: TVisibility = "private" as TVisibility,
+) {
+    let channel = resolveChannel(channelName, visibility);
+    let subscription: Connection<TDriver> =
+        resolveChannelSubscription<TDriver>(channel);
+
+    const tearDown = (leaveAll: boolean = false) => {
+        leaveChannel(channel, leaveAll);
+    };
+
+    $effect(() => {
+        channel = resolveChannel(channelName, visibility);
+        subscription = resolveChannelSubscription<TDriver>(channel);
+
+        return () => tearDown();
+    });
+
+    return {
+        /**
+         * Leave the channel
+         */
+        leaveChannel: tearDown,
+        /**
+         * Leave the channel and also its associated private and presence channels
+         */
+        leave: () => tearDown(true),
+        /**
+         * Channel instance
+         */
+        channel: () => subscription as ChannelReturnType<TDriver, TVisibility>,
+    };
+}
+
+export const usePresenceChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: ReactiveInput<string>,
+) => {
+    return useChannel<TDriver, "presence">(channelName, "presence");
+};
+
+export const usePublicChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: ReactiveInput<string>,
+) => {
+    return useChannel<TDriver, "public">(channelName, "public");
+};
+
 export const useEchoModel = <
     TPayload,
     TModel extends string,

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -357,10 +357,7 @@ export const useEchoPublic = <
 export function useChannel<
     TDriver extends BroadcastDriver = BroadcastDriver,
     TVisibility extends Channel["visibility"] = "private",
->(
-    channelName: string,
-    visibility: TVisibility = "private" as TVisibility,
-) {
+>(channelName: string, visibility: TVisibility = "private" as TVisibility) {
     const channel: Channel = {
         name: channelName,
         id: ["private", "presence"].includes(visibility)

--- a/packages/vue/src/composables/useEcho.ts
+++ b/packages/vue/src/composables/useEcho.ts
@@ -354,6 +354,64 @@ export const useEchoPublic = <
     );
 };
 
+export function useChannel<
+    TDriver extends BroadcastDriver = BroadcastDriver,
+    TVisibility extends Channel["visibility"] = "private",
+>(
+    channelName: string,
+    visibility: TVisibility = "private" as TVisibility,
+) {
+    const channel: Channel = {
+        name: channelName,
+        id: ["private", "presence"].includes(visibility)
+            ? `${visibility}-${channelName}`
+            : channelName,
+        visibility,
+    };
+
+    const subscription: Connection<TDriver> =
+        resolveChannelSubscription<TDriver>(channel);
+
+    const tearDown = (leaveAll: boolean = false) => {
+        leaveChannel(channel, leaveAll);
+    };
+
+    onUnmounted(() => {
+        tearDown();
+    });
+
+    return {
+        /**
+         * Leave the channel
+         */
+        leaveChannel: tearDown,
+        /**
+         * Leave the channel and also its associated private and presence channels
+         */
+        leave: () => tearDown(true),
+        /**
+         * Channel instance
+         */
+        channel: () => subscription as ChannelReturnType<TDriver, TVisibility>,
+    };
+}
+
+export const usePresenceChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: string,
+) => {
+    return useChannel<TDriver, "presence">(channelName, "presence");
+};
+
+export const usePublicChannel = <
+    TDriver extends BroadcastDriver = BroadcastDriver,
+>(
+    channelName: string,
+) => {
+    return useChannel<TDriver, "public">(channelName, "public");
+};
+
 export const useEchoModel = <
     TPayload,
     TModel extends string,

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,11 +1,14 @@
 export type { ConnectionStatus } from "laravel-echo";
 export {
+    useChannel,
     useConnectionStatus,
     useEcho,
     useEchoModel,
     useEchoNotification,
     useEchoPresence,
     useEchoPublic,
+    usePresenceChannel,
+    usePublicChannel,
     useSocketId,
 } from "./composables/useEcho";
 export { configureEcho, echo, echoIsConfigured } from "./config/index";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.25.1)
       jsdom:
-        specifier: '>=29.0.0'
+        specifier: ^29.1.1
         version: 29.1.1
       laravel-echo:
         specifier: workspace:^
@@ -152,7 +152,7 @@ importers:
         specifier: ^8.31.1
         version: 8.31.1(eslint@9.25.1)(typescript@5.8.3)
       esbuild:
-        specifier: '>=0.25.0'
+        specifier: ^0.28.1
         version: 0.28.1
       eslint:
         specifier: ^9.25.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.25.1)
       jsdom:
-        specifier: ^29.1.1
+        specifier: '>=29.0.0'
         version: 29.1.1
       laravel-echo:
         specifier: workspace:^
@@ -152,7 +152,7 @@ importers:
         specifier: ^8.31.1
         version: 8.31.1(eslint@9.25.1)(typescript@5.8.3)
       esbuild:
-        specifier: ^0.28.1
+        specifier: '>=0.25.0'
         version: 0.28.1
       eslint:
         specifier: ^9.25.1


### PR DESCRIPTION
Adds `useChannel`, `usePresenceChannel`, and `usePublicChannel` hooks across React, Vue, and Svelte. These provide a lower-level primitive for getting a managed channel subscription without binding to a specific event, useful for things like `whisper()` or presence callbacks.
