### PR TITLE
fix(react): allow useEcho without event or callback arguments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,9 @@ jobs:
       - name: ESLint
         run: pnpm run lint
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Execute tests
         run: pnpm test
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "packageManager": "pnpm@11.22.0",
     "scripts": {
         "test": "pnpm -r --if-present run test",
+        "typecheck": "pnpm -r --if-present run typecheck",
         "build": "pnpm -r --if-present run build",
         "lint": "pnpm -r --if-present run lint",
         "format": "pnpm -r --if-present run format",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -28,6 +28,7 @@
         "prepublish": "pnpm run build",
         "release": "vitest --run && pnpm publish --no-git-checks",
         "test": "vitest",
+        "typecheck": "tsc --noEmit -p tsconfig.json",
         "format": "prettier --write ."
     },
     "devDependencies": {

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -124,8 +124,8 @@ export function useEcho<
     TVisibility extends Channel["visibility"] = "private",
 >(
     channelName: string,
-    event: string | string[],
-    callback: (payload: TPayload) => void,
+    event?: string | string[],
+    callback?: (payload: TPayload) => void,
     dependencies?: DependencyList,
     visibility?: TVisibility,
 ): {

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -842,10 +842,10 @@ describe("useEchoPresence hook", async () => {
         expect(typeof result.current.leaveChannel).toBe("function");
         expect(result.current).toHaveProperty("channel");
         expect(result.current.channel).not.toBeNull();
-        expect(typeof result.current.channel().here).toBe("function");
-        expect(typeof result.current.channel().joining).toBe("function");
-        expect(typeof result.current.channel().leaving).toBe("function");
-        expect(typeof result.current.channel().whisper).toBe("function");
+        expect(typeof result.current.channel()!.here).toBe("function");
+        expect(typeof result.current.channel()!.joining).toBe("function");
+        expect(typeof result.current.channel()!.leaving).toBe("function");
+        expect(typeof result.current.channel()!.whisper).toBe("function");
     });
 
     it("handles multiple events", async () => {


### PR DESCRIPTION
## Problem

`useEcho` has defaulted `event` and `callback` since they were introduced, and there is a test asserting it — `"events and listeners are optional"` in `tests/use-echo.test.ts`. But all three overloads declare both parameters as required, so the shipped `dist/index.d.ts` rejects the call:

```ts
useEcho("orders");            // TS2554: Expected 3-5 arguments, but got 1
useEcho("orders", "Shipped"); // TS2554: Expected 3-5 arguments, but got 2
```

Both work fine at runtime. `useEchoPublic`, `useEchoPresence`, `useEchoModel` and `useEchoNotification` are arrow functions with real defaults, so they were never affected — only `useEcho` itself.

## Why it went unnoticed

The react package includes `./tests/**/*.ts` in its `tsconfig.json`, but nothing in CI ever ran `tsc`. The build only emits declarations for `src/`, so the error sat in the test file unreported. `tsc --noEmit` on `2.x` today reports 5 errors, one of them being that very test.

## Changes

1. `event` and `callback` are optional on the general overload. The two inference overloads are untouched, so payload inference from the global `Events` interface resolves exactly as before.
2. A `typecheck` script on the react package plus a recursive one at the root, wired into the `tests` workflow after ESLint. The 4 remaining errors it surfaced were unrelated null assertions in the presence tests, fixed here too.

The root script uses `--if-present`, so adding `typecheck` to the other packages later needs no workflow change. I left them out deliberately: `vue`, `svelte` and `laravel-echo` all exclude `tests/**` from their tsconfig, so a gate there would only cover `src/` and give weaker cover than it appears to. Aligning those is a reasonable follow-up.

## Verification

`pnpm build`, `pnpm run lint`, `pnpm run typecheck` and `pnpm test` all pass. Verified against the built `dist/index.d.ts` that both call shapes above now compile.