### PR TITLE
fix(react): correct the useEcho subscription lifecycle

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -33,11 +33,10 @@
     "devDependencies": {
         "@eslint-react/eslint-plugin": "^2.5.1",
         "@testing-library/dom": "^10.4.0",
-        "@testing-library/react": "^14.3.1",
-        "@testing-library/react-hooks": "^8.0.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^20.17.32",
-        "@types/react": "^19.1.2",
-        "@types/react-dom": "^19.1.3",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
         "eslint": "^9.25.1",
@@ -46,8 +45,8 @@
         "laravel-echo": "workspace:^",
         "prettier": "^3.5.3",
         "pusher-js": "^8.4.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0",
+        "react": "^19.2.0",
+        "react-dom": "^19.2.0",
         "socket.io-client": "^4.8.1",
         "typescript": "^5.8.3",
         "vite": "^6.4.3",
@@ -56,7 +55,7 @@
     },
     "peerDependencies": {
         "pusher-js": "*",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
         "socket.io-client": "*"
     },
     "peerDependenciesMeta": {

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -145,6 +145,9 @@ export function useEcho<
     channelName: string,
     event: string | string[] = [],
     callback: (payload: TPayload) => void = () => {},
+    /* Kept for backwards compatibility: `visibility` is positional after it, and the
+       listener now always reaches the latest callback, so there is nothing to key on. */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     dependencies: DependencyList = [],
     visibility: TVisibility = "private" as TVisibility,
 ) {
@@ -159,9 +162,17 @@ export function useEcho<
         [channelName, visibility],
     );
 
-    // callback and dependencies are parameters meant to be used directly
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const callbackFunc = useCallback(callback, dependencies);
+    const callbackRef = useRef(callback);
+
+    useEffect(() => {
+        callbackRef.current = callback;
+    });
+
+    // Stable for the subscription's lifetime, so a changing callback never costs a resubscribe.
+    const callbackFunc = useCallback(
+        (payload: TPayload) => callbackRef.current(payload),
+        [],
+    );
     const listening = useRef(false);
     const subscription = useRef<Connection<TDriver> | null>(null);
 
@@ -278,9 +289,11 @@ export const useEchoNotification = <
     }, [eventKey]);
 
     const listening = useRef(false);
+    const callbackRef = useRef(callback);
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const memoizedCallback = useCallback(callback, dependencies);
+    useEffect(() => {
+        callbackRef.current = callback;
+    });
 
     const cb = useCallback(
         (notification: BroadcastNotification<TPayload>) => {
@@ -289,10 +302,10 @@ export const useEchoNotification = <
             }
 
             if (events.length === 0 || events.includes(notification.type)) {
-                memoizedCallback(notification);
+                callbackRef.current(notification);
             }
         },
-        [memoizedCallback, events],
+        [events],
     );
 
     const listen = useCallback(() => {

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -3,7 +3,6 @@ import {
     type DependencyList,
     useCallback,
     useEffect,
-    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -494,29 +493,29 @@ export const useEchoModel = <
 
 const useConnectionChange = (
     callback: (status: ConnectionStatus) => void,
-    invokeOnMount: boolean = true,
 ): void => {
     const callbackRef = useRef(callback);
 
-    useLayoutEffect(() => {
+    useEffect(() => {
         callbackRef.current = callback;
     });
 
     useEffect(() => {
-        if (invokeOnMount) {
-            callbackRef.current(echo().connectionStatus());
-        }
+        callbackRef.current(echo().connectionStatus());
 
         return echo().connector.onConnectionChange((status) =>
             callbackRef.current(status),
         );
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    }, []);
 };
 
+/*
+ * Both hooks below read the connection through the effect rather than a state
+ * initialiser: `echo()` constructs the instance and opens the socket, which must not
+ * happen while rendering — least of all on the server.
+ */
 export const useConnectionStatus = (): ConnectionStatus => {
-    const [status, setStatus] = useState<ConnectionStatus>(() =>
-        echo().connectionStatus(),
-    );
+    const [status, setStatus] = useState<ConnectionStatus>("disconnected");
 
     useConnectionChange((newStatus) => {
         setStatus(newStatus);
@@ -526,13 +525,11 @@ export const useConnectionStatus = (): ConnectionStatus => {
 };
 
 export const useSocketId = (): string | undefined => {
-    const [socketId, setSocketId] = useState<string | undefined>(() =>
-        echo().socketId(),
-    );
+    const [socketId, setSocketId] = useState<string | undefined>(undefined);
 
     useConnectionChange(() => {
         setSocketId(echo().socketId());
-    }, false);
+    });
 
     return socketId;
 };

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -204,8 +204,19 @@ export function useEcho<
         listening.current = true;
     }, [events, callbackFunc]);
 
+    /* One release per acquire: `leaveChannel` is handed to the caller and also used as
+       the effect cleanup, so without this the two together would decrement the shared
+       refcount twice and drop a channel another mounted consumer still holds. */
+    const subscribedRef = useRef(false);
+
     const tearDown = useCallback(
         (leaveAll: boolean = false) => {
+            if (!subscribedRef.current) {
+                return;
+            }
+
+            subscribedRef.current = false;
+
             stopListening();
 
             leaveChannel(channel, leaveAll);
@@ -219,6 +230,7 @@ export function useEcho<
 
     useEffect(() => {
         subscription.current = resolveChannelSubscription<TDriver>(channel);
+        subscribedRef.current = true;
 
         listen();
 
@@ -414,9 +426,17 @@ export function useChannel<
     );
 
     const subscription = useRef<Connection<TDriver> | null>(null);
+    // See the matching guard in useEcho: one release per acquire.
+    const subscribedRef = useRef(false);
 
     const tearDown = useCallback(
         (leaveAll: boolean = false) => {
+            if (!subscribedRef.current) {
+                return;
+            }
+
+            subscribedRef.current = false;
+
             leaveChannel(channel, leaveAll);
         },
         [channel],
@@ -428,6 +448,7 @@ export function useChannel<
 
     useEffect(() => {
         subscription.current = resolveChannelSubscription<TDriver>(channel);
+        subscribedRef.current = true;
 
         return () => tearDown();
     }, [tearDown, channel]);

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -144,8 +144,7 @@ export function useEcho<
     channelName: string,
     event: string | string[] = [],
     callback: (payload: TPayload) => void = () => {},
-    /* Kept for backwards compatibility: `visibility` is positional after it, and the
-       listener now always reaches the latest callback, so there is nothing to key on. */
+    // Unused, but `visibility` is positional after it: removing it would break callers.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     dependencies: DependencyList = [],
     visibility: TVisibility = "private" as TVisibility,
@@ -167,7 +166,7 @@ export function useEcho<
         callbackRef.current = callback;
     });
 
-    // Stable for the subscription's lifetime, so a changing callback never costs a resubscribe.
+    // Kept stable so a changing callback never costs an unsubscribe and resubscribe.
     const callbackFunc = useCallback(
         (payload: TPayload) => callbackRef.current(payload),
         [],
@@ -204,9 +203,8 @@ export function useEcho<
         listening.current = true;
     }, [events, callbackFunc]);
 
-    /* One release per acquire: `leaveChannel` is handed to the caller and also used as
-       the effect cleanup, so without this the two together would decrement the shared
-       refcount twice and drop a channel another mounted consumer still holds. */
+    /* `leaveChannel` is both returned to the caller and used as the effect cleanup: without
+       this guard the two decrement the shared refcount twice, dropping a live channel. */
     const subscribedRef = useRef(false);
 
     const tearDown = useCallback(
@@ -426,7 +424,7 @@ export function useChannel<
     );
 
     const subscription = useRef<Connection<TDriver> | null>(null);
-    // See the matching guard in useEcho: one release per acquire.
+    // One release per acquire, as in useEcho.
     const subscribedRef = useRef(false);
 
     const tearDown = useCallback(
@@ -515,8 +513,7 @@ export const useEchoModel = <
 const subscribeToConnectionChange = (onStoreChange: () => void): (() => void) =>
     echo().connector.onConnectionChange(onStoreChange);
 
-/* The server snapshots keep `echo()` out of rendering on the server: constructing the
-   instance opens a socket, which must not happen while producing markup in Node. */
+// The server snapshots keep `echo()` out of server rendering: constructing it opens a socket.
 export const useConnectionStatus = (): ConnectionStatus =>
     useSyncExternalStore(
         subscribeToConnectionChange,

--- a/packages/react/src/hooks/use-echo.ts
+++ b/packages/react/src/hooks/use-echo.ts
@@ -5,7 +5,7 @@ import {
     useEffect,
     useMemo,
     useRef,
-    useState,
+    useSyncExternalStore,
 } from "react";
 import { echo } from "../config";
 import type {
@@ -512,45 +512,21 @@ export const useEchoModel = <
     );
 };
 
-const useConnectionChange = (
-    callback: (status: ConnectionStatus) => void,
-): void => {
-    const callbackRef = useRef(callback);
+const subscribeToConnectionChange = (onStoreChange: () => void): (() => void) =>
+    echo().connector.onConnectionChange(onStoreChange);
 
-    useEffect(() => {
-        callbackRef.current = callback;
-    });
+/* The server snapshots keep `echo()` out of rendering on the server: constructing the
+   instance opens a socket, which must not happen while producing markup in Node. */
+export const useConnectionStatus = (): ConnectionStatus =>
+    useSyncExternalStore(
+        subscribeToConnectionChange,
+        () => echo().connectionStatus(),
+        () => "disconnected",
+    );
 
-    useEffect(() => {
-        callbackRef.current(echo().connectionStatus());
-
-        return echo().connector.onConnectionChange((status) =>
-            callbackRef.current(status),
-        );
-    }, []);
-};
-
-/*
- * Both hooks below read the connection through the effect rather than a state
- * initialiser: `echo()` constructs the instance and opens the socket, which must not
- * happen while rendering — least of all on the server.
- */
-export const useConnectionStatus = (): ConnectionStatus => {
-    const [status, setStatus] = useState<ConnectionStatus>("disconnected");
-
-    useConnectionChange((newStatus) => {
-        setStatus(newStatus);
-    });
-
-    return status;
-};
-
-export const useSocketId = (): string | undefined => {
-    const [socketId, setSocketId] = useState<string | undefined>(undefined);
-
-    useConnectionChange(() => {
-        setSocketId(echo().socketId());
-    });
-
-    return socketId;
-};
+export const useSocketId = (): string | undefined =>
+    useSyncExternalStore(
+        subscribeToConnectionChange,
+        () => echo().socketId(),
+        () => undefined,
+    );

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -160,7 +160,6 @@ describe("useEcho hook", async () => {
 
         expect(() => unmount()).not.toThrow();
 
-        // whatever was registered has to be exactly what gets removed
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
             firstListener,
@@ -452,7 +451,6 @@ describe("useEcho hook", async () => {
             echoModule.useEcho(channelName, event, vi.fn()),
         );
 
-        // consumer one opts out explicitly, then goes away
         first.result.current.leaveChannel();
         first.unmount();
 

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -1761,3 +1761,65 @@ describe("useConnectionStatus hook", async () => {
         expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 });
+
+describe("server rendering", async () => {
+    let echoModule: typeof import("../src/hooks/use-echo");
+    let configModule: typeof import("../src/config/index");
+    let renderToStaticMarkup: typeof import("react-dom/server").renderToStaticMarkup;
+    let createElement: typeof import("react").createElement;
+
+    beforeEach(async () => {
+        vi.resetModules();
+
+        echoModule = await getEchoModule();
+        configModule = await getConfigModule();
+        ({ renderToStaticMarkup } = await import("react-dom/server"));
+        ({ createElement } = await import("react"));
+
+        configModule.configureEcho({
+            broadcaster: "null",
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders useConnectionStatus without opening a connection", async () => {
+        const Echo = (await import("laravel-echo")).default as any;
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const Component = () =>
+            createElement("span", null, echoModule.useConnectionStatus());
+
+        const constructedBefore = Echo.mock.calls.length;
+
+        expect(renderToStaticMarkup(createElement(Component))).toBe(
+            "<span>disconnected</span>",
+        );
+
+        expect(Echo.mock.calls.length).toBe(constructedBefore);
+        expect(errors).not.toHaveBeenCalled();
+
+        errors.mockRestore();
+    });
+
+    it("renders useSocketId without opening a connection", async () => {
+        const Echo = (await import("laravel-echo")).default as any;
+        const errors = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const Component = () =>
+            createElement("span", null, echoModule.useSocketId() ?? "none");
+
+        const constructedBefore = Echo.mock.calls.length;
+
+        expect(renderToStaticMarkup(createElement(Component))).toBe(
+            "<span>none</span>",
+        );
+
+        expect(Echo.mock.calls.length).toBe(constructedBefore);
+        expect(errors).not.toHaveBeenCalled();
+
+        errors.mockRestore();
+    });
+});

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -1758,10 +1758,9 @@ describe("useSocketId hook", async () => {
         const Echo = (await import("laravel-echo")).default as any;
         let connectionCallback: (() => void) | undefined;
 
-        Echo.prototype.socketId = vi
-            .fn()
-            .mockReturnValueOnce(undefined)
-            .mockReturnValue("new-socket.abc123");
+        let currentSocketId: string | undefined = undefined;
+
+        Echo.prototype.socketId = vi.fn(() => currentSocketId);
         Echo.prototype.connector = {
             onConnectionChange: vi.fn((cb: () => void) => {
                 connectionCallback = cb;
@@ -1772,7 +1771,9 @@ describe("useSocketId hook", async () => {
         const { result } = renderHook(() => echoModule.useSocketId());
         expect(result.current).toBeUndefined();
 
+        currentSocketId = "new-socket.abc123";
         act(() => connectionCallback?.());
+
         expect(result.current).toBe("new-socket.abc123");
     });
 });
@@ -1804,21 +1805,22 @@ describe("useConnectionStatus hook", async () => {
 
     it("updates when the connector reports a new status", async () => {
         const Echo = (await import("laravel-echo")).default as any;
-        let connectionCallback: ((status: ConnectionStatus) => void) | undefined;
+        let connectionCallback: (() => void) | undefined;
+        let currentStatus: ConnectionStatus = "connected";
 
+        Echo.prototype.connectionStatus = vi.fn(() => currentStatus);
         Echo.prototype.connector = {
-            onConnectionChange: vi.fn(
-                (cb: (status: ConnectionStatus) => void) => {
-                    connectionCallback = cb;
-                    return () => {};
-                },
-            ),
+            onConnectionChange: vi.fn((cb: () => void) => {
+                connectionCallback = cb;
+                return () => {};
+            }),
         };
 
         const { result } = renderHook(() => echoModule.useConnectionStatus());
         expect(result.current).toBe("connected");
 
-        act(() => connectionCallback?.("reconnecting"));
+        currentStatus = "reconnecting";
+        act(() => connectionCallback?.());
 
         expect(result.current).toBe("reconnecting");
     });

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import Echo from "laravel-echo";
+import Echo, { type ConnectionStatus } from "laravel-echo";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getEchoModule = async () => import("../src/hooks/use-echo");
@@ -1335,6 +1335,140 @@ describe("useEchoNotification hook", async () => {
     });
 });
 
+describe("useChannel hook", async () => {
+    let echoModule: typeof import("../src/hooks/use-echo");
+    let configModule: typeof import("../src/config/index");
+    let echoInstance: Echo<"null">;
+
+    beforeEach(async () => {
+        vi.resetModules();
+
+        echoInstance = new Echo({
+            broadcaster: "null",
+        });
+
+        echoModule = await getEchoModule();
+        configModule = await getConfigModule();
+
+        configModule.configureEcho({
+            broadcaster: "null",
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("subscribes to a private channel by default", async () => {
+        const channelName = "test-channel";
+
+        const { result } = renderHook(() => echoModule.useChannel(channelName));
+
+        expect(echoInstance.private).toHaveBeenCalledWith(channelName);
+        expect(result.current.channel()).not.toBeNull();
+    });
+
+    it("does not register any event listeners", async () => {
+        const channelName = "test-channel";
+
+        renderHook(() => echoModule.useChannel(channelName));
+
+        expect(echoInstance.private(channelName).listen).not.toHaveBeenCalled();
+    });
+
+    it("leaves the channel on unmount", async () => {
+        const channelName = "test-channel";
+
+        const { unmount } = renderHook(() =>
+            echoModule.useChannel(channelName),
+        );
+
+        expect(() => unmount()).not.toThrow();
+
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `private-${channelName}`,
+        );
+    });
+
+    it("can leave all channel variations", async () => {
+        const channelName = "test-channel";
+
+        const { result } = renderHook(() => echoModule.useChannel(channelName));
+
+        result.current.leave();
+
+        expect(echoInstance.leave).toHaveBeenCalledWith(channelName);
+    });
+
+    it("won't subscribe multiple times to the same channel", async () => {
+        const channelName = "test-channel";
+
+        const { unmount: unmount1 } = renderHook(() =>
+            echoModule.useChannel(channelName),
+        );
+        const { unmount: unmount2 } = renderHook(() =>
+            echoModule.useChannel(channelName),
+        );
+
+        expect(echoInstance.private).toHaveBeenCalledTimes(1);
+
+        expect(() => unmount1()).not.toThrow();
+        expect(echoInstance.leaveChannel).not.toHaveBeenCalled();
+
+        expect(() => unmount2()).not.toThrow();
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `private-${channelName}`,
+        );
+    });
+
+    it("shares one subscription with useEcho on the same channel", async () => {
+        const channelName = "test-channel";
+
+        const listener = renderHook(() =>
+            echoModule.useEcho(channelName, "test-event", vi.fn()),
+        );
+        const holder = renderHook(() => echoModule.useChannel(channelName));
+
+        expect(echoInstance.private).toHaveBeenCalledTimes(1);
+        expect(holder.result.current.channel()).toBe(
+            listener.result.current.channel(),
+        );
+    });
+
+    it("subscribes to a public channel via usePublicChannel", async () => {
+        const channelName = "test-channel";
+
+        const { result, unmount } = renderHook(() =>
+            echoModule.usePublicChannel(channelName),
+        );
+
+        expect(echoInstance.channel).toHaveBeenCalledWith(channelName);
+        expect(result.current.channel()).not.toBeNull();
+
+        unmount();
+
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(channelName);
+    });
+
+    it("subscribes to a presence channel via usePresenceChannel", async () => {
+        const channelName = "test-channel";
+
+        const { result, unmount } = renderHook(() =>
+            echoModule.usePresenceChannel(channelName),
+        );
+
+        expect(echoInstance.join).toHaveBeenCalledWith(channelName);
+        expect(typeof result.current.channel()!.here).toBe("function");
+        expect(typeof result.current.channel()!.whisper).toBe("function");
+
+        unmount();
+
+        expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
+            `presence-${channelName}`,
+        );
+    });
+});
+
 describe("useSocketId hook", async () => {
     let echoModule: typeof import("../src/hooks/use-echo");
     let configModule: typeof import("../src/config/index");
@@ -1393,7 +1527,7 @@ describe("useSocketId hook", async () => {
     });
 });
 
-describe.skip("useConnectionStatus hook", async () => {
+describe("useConnectionStatus hook", async () => {
     let echoModule: typeof import("../src/hooks/use-echo");
     let configModule: typeof import("../src/config/index");
 
@@ -1416,5 +1550,43 @@ describe.skip("useConnectionStatus hook", async () => {
         const { result } = renderHook(() => echoModule.useConnectionStatus());
 
         expect(result.current).toBe("connected");
+    });
+
+    it("updates when the connector reports a new status", async () => {
+        const Echo = (await import("laravel-echo")).default as any;
+        let connectionCallback: ((status: ConnectionStatus) => void) | undefined;
+
+        Echo.prototype.connector = {
+            onConnectionChange: vi.fn(
+                (cb: (status: ConnectionStatus) => void) => {
+                    connectionCallback = cb;
+                    return () => {};
+                },
+            ),
+        };
+
+        const { result } = renderHook(() => echoModule.useConnectionStatus());
+        expect(result.current).toBe("connected");
+
+        act(() => connectionCallback?.("reconnecting"));
+
+        expect(result.current).toBe("reconnecting");
+    });
+
+    it("unsubscribes from the connector on unmount", async () => {
+        const Echo = (await import("laravel-echo")).default as any;
+        const unsubscribe = vi.fn();
+
+        Echo.prototype.connector = {
+            onConnectionChange: vi.fn(() => unsubscribe),
+        };
+
+        const { unmount } = renderHook(() => echoModule.useConnectionStatus());
+
+        expect(unsubscribe).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -224,7 +224,10 @@ describe("useEcho hook", async () => {
 
         const channel = echoInstance.private(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(event, expect.any(Function));
+        expect(channel.listen).toHaveBeenCalledWith(
+            event,
+            expect.any(Function),
+        );
 
         registeredListener(channel, event)({ id: 7 });
 
@@ -1456,12 +1459,7 @@ describe("useEchoNotification hook", async () => {
 
         const { rerender } = renderHook(
             ({ deps }: { deps: unknown[] }) =>
-                echoModule.useEchoNotification(
-                    channelName,
-                    vi.fn(),
-                    [],
-                    deps,
-                ),
+                echoModule.useEchoNotification(channelName, vi.fn(), [], deps),
             { initialProps: { deps: [1] as unknown[] } },
         );
 

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -47,6 +47,21 @@ vi.mock("laravel-echo", () => {
     return { default: Echo };
 });
 
+const registeredListener = (
+    channel: { listen: (event: string, callback: CallableFunction) => unknown },
+    event: string,
+) => {
+    const calls = vi
+        .mocked(channel.listen)
+        .mock.calls.filter(([registeredEvent]) => registeredEvent === event);
+
+    if (calls.length === 0) {
+        throw new Error(`No listener was registered for "${event}".`);
+    }
+
+    return calls[calls.length - 1][1] as (payload: unknown) => void;
+};
+
 describe("without echo configured", async () => {
     beforeEach(() => {
         vi.resetModules();
@@ -127,18 +142,32 @@ describe("useEcho hook", async () => {
 
         const channel = echoInstance.private(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[0],
+            expect.any(Function),
+        );
+        expect(channel.listen).toHaveBeenCalledWith(
+            events[1],
+            expect.any(Function),
+        );
+
+        const firstListener = registeredListener(channel, events[0]);
+        const secondListener = registeredListener(channel, events[1]);
+
+        firstListener({ order: 1 });
+
+        expect(mockCallback).toHaveBeenCalledWith({ order: 1 });
 
         expect(() => unmount()).not.toThrow();
 
+        // whatever was registered has to be exactly what gets removed
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            firstListener,
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            secondListener,
         );
     });
 
@@ -193,10 +222,13 @@ describe("useEcho hook", async () => {
 
         expect(echoInstance.private).toHaveBeenCalledWith(channelName);
 
-        expect(echoInstance.private(channelName).listen).toHaveBeenCalledWith(
-            event,
-            mockCallback,
-        );
+        const channel = echoInstance.private(channelName);
+
+        expect(channel.listen).toHaveBeenCalledWith(event, expect.any(Function));
+
+        registeredListener(channel, event)({ id: 7 });
+
+        expect(mockCallback).toHaveBeenCalledWith({ id: 7 });
     });
 
     it("can leave a channel", async () => {
@@ -256,15 +288,16 @@ describe("useEcho hook", async () => {
 
         const channel = echoInstance.private(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(event, mockCallback);
+        const listener = registeredListener(channel, event);
 
         result.current.stopListening();
 
-        expect(channel.stopListening).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.stopListening).toHaveBeenCalledWith(event, listener);
 
         result.current.listen();
 
-        expect(channel.listen).toHaveBeenCalledWith(event, mockCallback);
+        expect(vi.mocked(channel.listen).mock.calls).toHaveLength(2);
+        expect(registeredListener(channel, event)).toBe(listener);
     });
 
     it("can manually stop listening to events", async () => {
@@ -276,10 +309,12 @@ describe("useEcho hook", async () => {
             echoModule.useEcho(channelName, event, mockCallback),
         );
 
+        const channel = echoInstance.private(channelName);
+        const listener = registeredListener(channel, event);
+
         result.current.stopListening();
 
-        const channel = echoInstance.private(channelName);
-        expect(channel.stopListening).toHaveBeenCalledWith(event, mockCallback);
+        expect(channel.stopListening).toHaveBeenCalledWith(event, listener);
     });
 
     it("stopListening is a no-op when not listening", async () => {
@@ -341,18 +376,19 @@ describe("useEcho hook", async () => {
         );
 
         const channel = echoInstance.private(channelName);
-        const firstCallback = vi.mocked(channel.listen).mock.calls[0][1];
+        const listener = registeredListener(channel, event);
 
-        expect(firstCallback).toBe(mockCallback1);
+        listener({ id: 1 });
+
+        expect(mockCallback1).toHaveBeenCalledWith({ id: 1 });
 
         dependency = "value2";
         rerender({ deps: [dependency], callback: mockCallback2 });
 
-        const secondCallback = vi.mocked(channel.listen).mock.calls[
-            vi.mocked(channel.listen).mock.calls.length - 1
-        ][1];
+        listener({ id: 2 });
 
-        expect(secondCallback).toBe(mockCallback2);
+        expect(mockCallback2).toHaveBeenCalledWith({ id: 2 });
+        expect(mockCallback1).toHaveBeenCalledTimes(1);
     });
 
     it("maintains callback stability when dependencies don't change", async () => {
@@ -400,6 +436,76 @@ describe("useEcho hook", async () => {
         const secondResult = result.current;
 
         expect(firstResult).toBe(secondResult);
+    });
+
+    it("does not resubscribe the channel when dependencies change", async () => {
+        const channelName = "dependency-change-channel";
+        const event = "test-event";
+
+        const { rerender } = renderHook(
+            ({ deps }: { deps: unknown[] }) =>
+                echoModule.useEcho(channelName, event, vi.fn(), deps),
+            { initialProps: { deps: [1] as unknown[] } },
+        );
+
+        rerender({ deps: [2] });
+        rerender({ deps: [3] });
+
+        const subscribes = vi
+            .mocked(echoInstance.private)
+            .mock.calls.filter(([name]) => name === channelName);
+        const leaves = vi
+            .mocked(echoInstance.leaveChannel)
+            .mock.calls.filter(([id]) => id === `private-${channelName}`);
+
+        expect(subscribes).toHaveLength(1);
+        expect(leaves).toHaveLength(0);
+    });
+
+    it("invokes the latest callback when no dependency array is passed", async () => {
+        const channelName = "test-channel";
+        const event = "test-event";
+        const received: number[] = [];
+
+        const { rerender } = renderHook(
+            ({ value }: { value: number }) =>
+                echoModule.useEcho(channelName, event, () => {
+                    received.push(value);
+                }),
+            { initialProps: { value: 1 } },
+        );
+
+        const listener = registeredListener(
+            echoInstance.private(channelName),
+            event,
+        );
+
+        rerender({ value: 2 });
+        listener({});
+
+        expect(received).toEqual([2]);
+    });
+
+    it("stays stopped after stopListening when dependencies change", async () => {
+        const channelName = "test-channel";
+        const event = "test-event";
+
+        const { result, rerender } = renderHook(
+            ({ deps }: { deps: unknown[] }) =>
+                echoModule.useEcho(channelName, event, vi.fn(), deps),
+            { initialProps: { deps: [1] as unknown[] } },
+        );
+
+        result.current.stopListening();
+
+        const channel = echoInstance.private(channelName);
+        const callsWhileStopped = vi.mocked(channel.listen).mock.calls.length;
+
+        rerender({ deps: [2] });
+
+        expect(vi.mocked(channel.listen).mock.calls.length).toBe(
+            callsWhileStopped,
+        );
     });
 
     it("handles array event dependencies with stable eventKey", async () => {
@@ -493,24 +599,22 @@ describe("useEchoModel hook", async () => {
 
         const channel = echoInstance.private(expectedChannelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(
-            `.${events[0]}`,
-            mockCallback,
-        );
-        expect(channel.listen).toHaveBeenCalledWith(
-            `.${events[1]}`,
-            mockCallback,
-        );
+        const firstListener = registeredListener(channel, `.${events[0]}`);
+        const secondListener = registeredListener(channel, `.${events[1]}`);
+
+        firstListener({ model: { id: 123 } });
+
+        expect(mockCallback).toHaveBeenCalledWith({ model: { id: 123 } });
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             `.${events[0]}`,
-            mockCallback,
+            firstListener,
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             `.${events[1]}`,
-            mockCallback,
+            secondListener,
         );
     });
 
@@ -639,7 +743,15 @@ describe("useEchoModel hook", async () => {
         expect(echoInstance.private).toHaveBeenCalledWith(expectedChannelName);
 
         const channel = echoInstance.private(expectedChannelName);
-        expect(channel.listen).toHaveBeenCalledWith(`.${event}`, mockCallback);
+
+        expect(channel.listen).toHaveBeenCalledWith(
+            `.${event}`,
+            expect.any(Function),
+        );
+
+        registeredListener(channel, `.${event}`)({ model: { id: 1 } });
+
+        expect(mockCallback).toHaveBeenCalledWith({ model: { id: 1 } });
     });
 
     it("events and listeners are optional", async () => {
@@ -709,18 +821,22 @@ describe("useEchoPublic hook", async () => {
 
         const channel = echoInstance.channel(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        const firstListener = registeredListener(channel, events[0]);
+        const secondListener = registeredListener(channel, events[1]);
+
+        firstListener({ order: 1 });
+
+        expect(mockCallback).toHaveBeenCalledWith({ order: 1 });
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            firstListener,
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            secondListener,
         );
     });
 
@@ -863,18 +979,22 @@ describe("useEchoPresence hook", async () => {
 
         const channel = echoInstance.join(channelName);
 
-        expect(channel.listen).toHaveBeenCalledWith(events[0], mockCallback);
-        expect(channel.listen).toHaveBeenCalledWith(events[1], mockCallback);
+        const firstListener = registeredListener(channel, events[0]);
+        const secondListener = registeredListener(channel, events[1]);
+
+        firstListener({ order: 1 });
+
+        expect(mockCallback).toHaveBeenCalledWith({ order: 1 });
 
         expect(() => unmount()).not.toThrow();
 
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[0],
-            mockCallback,
+            firstListener,
         );
         expect(channel.stopListening).toHaveBeenCalledWith(
             events[1],
-            mockCallback,
+            secondListener,
         );
     });
 
@@ -1251,6 +1371,57 @@ describe("useEchoNotification hook", async () => {
 
         expect(result.current).toHaveProperty("channel");
         expect(result.current.channel).not.toBeNull();
+    });
+
+    it("invokes the latest callback when no dependency array is passed", async () => {
+        const channelName = "test-channel";
+        const received: number[] = [];
+
+        const { rerender } = renderHook(
+            ({ value }: { value: number }) =>
+                echoModule.useEchoNotification(channelName, () => {
+                    received.push(value);
+                }),
+            { initialProps: { value: 1 } },
+        );
+
+        const channel = echoInstance.private(channelName);
+        const calls = vi.mocked(channel.notification).mock.calls;
+        const listener = calls[calls.length - 1][0];
+
+        rerender({ value: 2 });
+
+        listener({ id: "1", type: "App\\Notifications\\Any" });
+
+        expect(received).toEqual([2]);
+    });
+
+    it("does not resubscribe the channel when dependencies change", async () => {
+        const channelName = "notification-dependency-change";
+
+        const { rerender } = renderHook(
+            ({ deps }: { deps: unknown[] }) =>
+                echoModule.useEchoNotification(
+                    channelName,
+                    vi.fn(),
+                    [],
+                    deps,
+                ),
+            { initialProps: { deps: [1] as unknown[] } },
+        );
+
+        rerender({ deps: [2] });
+        rerender({ deps: [3] });
+
+        const subscribes = vi
+            .mocked(echoInstance.private)
+            .mock.calls.filter(([name]) => name === channelName);
+        const leaves = vi
+            .mocked(echoInstance.leaveChannel)
+            .mock.calls.filter(([id]) => id === `private-${channelName}`);
+
+        expect(subscribes).toHaveLength(1);
+        expect(leaves).toHaveLength(0);
     });
 
     it("maintains callback stability when dependencies don't change", async () => {

--- a/packages/react/tests/use-echo.test.ts
+++ b/packages/react/tests/use-echo.test.ts
@@ -438,6 +438,61 @@ describe("useEcho hook", async () => {
         expect(firstResult).toBe(secondResult);
     });
 
+    it("does not leave a channel another mounted consumer still holds", async () => {
+        const channelName = "shared-release-channel";
+        const event = "test-event";
+
+        const first = renderHook(() =>
+            echoModule.useEcho(channelName, event, vi.fn()),
+        );
+        const second = renderHook(() =>
+            echoModule.useEcho(channelName, event, vi.fn()),
+        );
+
+        // consumer one opts out explicitly, then goes away
+        first.result.current.leaveChannel();
+        first.unmount();
+
+        const leaves = vi
+            .mocked(echoInstance.leaveChannel)
+            .mock.calls.filter(([id]) => id === `private-${channelName}`);
+
+        expect(leaves).toHaveLength(0);
+
+        second.unmount();
+
+        expect(
+            vi
+                .mocked(echoInstance.leaveChannel)
+                .mock.calls.filter(([id]) => id === `private-${channelName}`),
+        ).toHaveLength(1);
+    });
+
+    it("ignores repeated leaveChannel calls from the same consumer", async () => {
+        const channelName = "repeated-release-channel";
+        const event = "test-event";
+
+        const first = renderHook(() =>
+            echoModule.useEcho(channelName, event, vi.fn()),
+        );
+        const second = renderHook(() =>
+            echoModule.useEcho(channelName, event, vi.fn()),
+        );
+
+        first.result.current.leaveChannel();
+        first.result.current.leaveChannel();
+        first.result.current.leave();
+
+        const leaves = vi
+            .mocked(echoInstance.leaveChannel)
+            .mock.calls.filter(([id]) => id === `private-${channelName}`);
+
+        expect(leaves).toHaveLength(0);
+        expect(echoInstance.leave).not.toHaveBeenCalledWith(channelName);
+
+        second.unmount();
+    });
+
     it("does not resubscribe the channel when dependencies change", async () => {
         const channelName = "dependency-change-channel";
         const event = "test-event";
@@ -1590,6 +1645,30 @@ describe("useChannel hook", async () => {
         expect(echoInstance.leaveChannel).toHaveBeenCalledWith(
             `private-${channelName}`,
         );
+    });
+
+    it("does not leave a channel another mounted consumer still holds", async () => {
+        const channelName = "shared-holder-channel";
+
+        const first = renderHook(() => echoModule.useChannel(channelName));
+        const second = renderHook(() => echoModule.useChannel(channelName));
+
+        first.result.current.leaveChannel();
+        first.unmount();
+
+        expect(
+            vi
+                .mocked(echoInstance.leaveChannel)
+                .mock.calls.filter(([id]) => id === `private-${channelName}`),
+        ).toHaveLength(0);
+
+        second.unmount();
+
+        expect(
+            vi
+                .mocked(echoInstance.leaveChannel)
+                .mock.calls.filter(([id]) => id === `private-${channelName}`),
+        ).toHaveLength(1);
     });
 
     it("shares one subscription with useEcho on the same channel", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,20 +77,17 @@ importers:
         specifier: ^10.4.0
         version: 10.4.0
       '@testing-library/react':
-        specifier: ^14.3.1
-        version: 14.3.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@testing-library/react-hooks':
-        specifier: ^8.0.1
-        version: 8.0.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^20.17.32
         version: 20.17.32
       '@types/react':
-        specifier: ^19.1.2
-        version: 19.1.2
+        specifier: ^19.2.18
+        version: 19.2.18
       '@types/react-dom':
-        specifier: ^19.1.3
-        version: 19.1.3(@types/react@19.1.2)
+        specifier: ^19.2.4
+        version: 19.2.4(@types/react@19.2.18)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.31.1
         version: 8.31.1(@typescript-eslint/parser@8.31.1(eslint@9.25.1)(typescript@5.8.3))(eslint@9.25.1)(typescript@5.8.3)
@@ -116,11 +113,11 @@ importers:
         specifier: ^8.4.0
         version: 8.4.0
       react:
-        specifier: ^19.1.0
-        version: 19.1.0
+        specifier: ^19.2.0
+        version: 19.2.8
       react-dom:
-        specifier: ^19.1.0
-        version: 19.1.0(react@19.1.0)
+        specifier: ^19.2.0
+        version: 19.2.8(react@19.2.8)
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
@@ -898,28 +895,20 @@ packages:
     resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
     engines: {node: '>=14'}
 
-  '@testing-library/react-hooks@8.0.1':
-    resolution: {integrity: sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==}
-    engines: {node: '>=12'}
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
     peerDependencies:
-      '@types/react': ^16.9.0 || ^17.0.0
-      react: ^16.9.0 || ^17.0.0
-      react-dom: ^16.9.0 || ^17.0.0
-      react-test-renderer: ^16.9.0 || ^17.0.0
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
-      react-dom:
+      '@types/react-dom':
         optional: true
-      react-test-renderer:
-        optional: true
-
-  '@testing-library/react@14.3.1':
-    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      react: ^18.0.0
-      react-dom: ^18.0.0
 
   '@testing-library/svelte-core@1.0.0':
     resolution: {integrity: sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==}
@@ -980,18 +969,13 @@ packages:
   '@types/node@22.15.3':
     resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
 
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
-      '@types/react': ^18.0.0
+      '@types/react': ^19.2.0
 
-  '@types/react-dom@19.1.3':
-    resolution: {integrity: sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==}
-    peerDependencies:
-      '@types/react': ^19.0.0
-
-  '@types/react@19.1.2':
-    resolution: {integrity: sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==}
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
 
   '@types/sizzle@2.3.9':
     resolution: {integrity: sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==}
@@ -1366,6 +1350,9 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -2167,22 +2154,16 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  react-dom@19.1.0:
-    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
     peerDependencies:
-      react: ^19.1.0
-
-  react-error-boundary@3.1.4:
-    resolution: {integrity: sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==}
-    engines: {node: '>=10', npm: '>=6'}
-    peerDependencies:
-      react: '>=16.13.1'
+      react: ^19.2.8
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react@19.1.0:
-    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
     engines: {node: '>=0.10.0'}
 
   regenerator-runtime@0.14.1:
@@ -2225,8 +2206,8 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
-  scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3305,24 +3286,15 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/react-hooks@8.0.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@babel/runtime': 7.27.0
-      react: 19.1.0
-      react-error-boundary: 3.1.4(react@19.1.0)
+      '@testing-library/dom': 10.4.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     optionalDependencies:
-      '@types/react': 19.1.2
-      react-dom: 19.1.0(react@19.1.0)
-
-  '@testing-library/react@14.3.1(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
-    dependencies:
-      '@babel/runtime': 7.27.0
-      '@testing-library/dom': 9.3.4
-      '@types/react-dom': 18.3.7(@types/react@19.1.2)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-    transitivePeerDependencies:
-      - '@types/react'
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
 
   '@testing-library/svelte-core@1.0.0(svelte@5.55.7(@typescript-eslint/types@8.52.0))':
     dependencies:
@@ -3375,17 +3347,13 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/react-dom@18.3.7(@types/react@19.1.2)':
+  '@types/react-dom@19.2.4(@types/react@19.2.18)':
     dependencies:
-      '@types/react': 19.1.2
+      '@types/react': 19.2.18
 
-  '@types/react-dom@19.1.3(@types/react@19.1.2)':
+  '@types/react@19.2.18':
     dependencies:
-      '@types/react': 19.1.2
-
-  '@types/react@19.1.2':
-    dependencies:
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   '@types/sizzle@2.3.9': {}
 
@@ -3851,6 +3819,8 @@ snapshots:
       source-map-js: 1.2.1
 
   csstype@3.1.3: {}
+
+  csstype@3.2.3: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -4744,19 +4714,14 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-dom@19.1.0(react@19.1.0):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.1.0
-      scheduler: 0.26.0
-
-  react-error-boundary@3.1.4(react@19.1.0):
-    dependencies:
-      '@babel/runtime': 7.27.0
-      react: 19.1.0
+      react: 19.2.8
+      scheduler: 0.27.0
 
   react-is@17.0.2: {}
 
-  react@19.1.0: {}
+  react@19.2.8: {}
 
   regenerator-runtime@0.14.1: {}
 
@@ -4826,7 +4791,7 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
-  scheduler@0.26.0: {}
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 


### PR DESCRIPTION
Four related defects in the react hooks' subscription lifecycle, each with a regression test written first. Separate commits per fix, so any subset can be dropped.

## 1. A dependency change tore the channel down and resubscribed it

`useEcho` built its listener with `useCallback(callback, dependencies)` and keyed its effect on the result, so **any** change to the caller's dependency array unsubscribed the channel and resubscribed it. On a private or presence channel that is a pusher `unsubscribe`, a `subscribe`, and a `POST /broadcasting/auth` — per change. Events broadcast during the gap are lost.

Measured before the fix, three dependency changes on one hook:

```
subscribe calls  = 4   (expected 1)
leaveChannel     = 3   (expected 0)
```

This is the documented path, not an edge case — the Boost skill says *"Pass reactive state (from `useState`) in the deps array"*.

The listener is now stable for the lifetime of the subscription and reads the current callback through a ref, so the effect only re-runs when the channel or the event list actually changes. Same treatment for `useEchoNotification`.

Three things fall out of that:

- **The frozen callback is gone.** `dependencies` defaults to `[]`, so `useEcho(ch, ev, e => setTotal(total + 1))` captured first-render values forever. The README documents no `dependencies` parameter at all, so that was the default path for anyone reading it.
- **A dependency change no longer silently resumes listening** after a manual `stopListening()`.
- **StrictMode** no longer re-authenticates on every dependency change.

`dependencies` is still accepted — `visibility` is positional after it — but is no longer read.

## 2. A channel could be left while another component was still using it

`leaveChannel` is handed to the caller *and* used as the effect cleanup, so calling it and then unmounting decremented the shared refcount twice:

```
consumer A: leaveChannel()   // 2 -> 1, correct
consumer A: unmount          // 1 -> 0, unsubscribes while B is still listening
```

Each consumer now releases at most once per acquire, which also makes repeated `leaveChannel()`/`leave()` calls no-ops instead of stealing someone else's subscription. `useChannel` had the same defect.

## 3. `useConnectionStatus` and `useSocketId` opened a connection while rendering

Both read `echo()` from a `useState` initialiser, which runs during render. `echo()` lazily constructs the Echo instance and that constructor connects immediately, so server rendering either opened a socket in Node or threw before `configureEcho()` had run. There is a test now that server-renders both hooks and asserts no instance is constructed.

They are now `useSyncExternalStore` calls: the connector is an external store, so one source of truth, no tearing under concurrent rendering, and a `getServerSnapshot` that keeps `echo()` out of server rendering entirely.

That is what the peer bump is for — see below.

## 4. Untested hooks

`useChannel`, `usePublicChannel` and `usePresenceChannel` shipped in #532 with no tests. `useConnectionStatus` had a suite that was `describe.skip`'d when it was added in #469; it passes unchanged, so it is un-skipped here, plus coverage for status updates and connector cleanup.

## Breaking change: React 16.8 and 17 are dropped

`useSyncExternalStore` needs React 18, so the peer range becomes `^18.0.0 || ^19.0.0`.

Worth saying explicitly: I tried `useEffectEvent` for #1 first, since that is exactly the primitive for "stable function that sees the latest render". It cannot be used here. `react-hooks/rules-of-hooks` errors with *"can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down"* — and that constraint is real, not a lint quirk: the listener has to be handed to `channel.listen()` and outlive the effect, and `useEcho` also exposes `listen()` for callers to invoke from their own handlers. So the ref stays, and the bump is only for `useSyncExternalStore`. If you would rather not drop React 16.8/17 at all, dropping commits 5 and 6 leaves the three fixes intact on the current peer range.

## Notes for review

- The tests that asserted `channel.listen` was called *with the user's callback reference* now assert behaviour instead: that invoking the registered listener reaches the current callback, and that the function removed is exactly the one registered. That is a stronger assertion than before, but it is a real change to those tests and worth a look.
- `useEcho` and `useChannel` still each build their own `channel` memo and now each carry the release guard. Extracting that felt like it would bury the fixes, so I left it — happy to follow up.
- Not touched here, all pre-existing: `configureEcho()` never disconnects the old instance or clears the channel registry; `leave()` unsubscribes sibling channel variants without updating their refcounts; `pusher-js` is declared optional but imported unconditionally. Happy to open issues.

## Verification

`pnpm build`, `pnpm run lint` and `pnpm test` pass. 83 tests, up from 62 plus 1 skipped.

Typecheck is clean apart from 5 pre-existing errors in the test file, which #538 fixes.