### PR TITLE
[2.x] Resolve React Native consumers to the CommonJS bundle

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,6 +79,7 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
+            "react-native": "./dist/index.common.js",
             "import": "./dist/index.js",
             "require": "./dist/index.common.js"
         }


### PR DESCRIPTION
Fixes #453

React Native's Metro bundler cannot parse `import.meta`, but the ESM bundle must keep the literal `import.meta.env.VITE_*` accesses so that a consuming Laravel app's Vite build can statically inline the framework's broadcasting defaults. When Metro resolves the ESM bundle (the default with package exports enabled, as in current React Native / Expo), it fails at parse time.

Since #542, the CommonJS bundle contains no `import.meta` at all — the guarded env accesses are lowered at build time and safely resolve to `undefined`, so React Native users pass their configuration to `configureEcho()` explicitly.

This adds the community-endorsed [`react-native` export condition](https://reactnative.dev/blog/2023/06/21/package-exports-support), which Metro asserts by default, pointing it at the CommonJS bundle.

Verified resolution behavior (Node condition simulation):

| Consumer | Resolves to |
|---|---|
| `import` (Vite, bundlers) | `dist/index.js` (unchanged) |
| `require` | `dist/index.common.js` (unchanged) |
| `react-native` condition (Metro) | `dist/index.common.js` |

Only `@laravel/echo-react` is touched; `laravel-echo` core ships no `import.meta` in any bundle, and the Vue/Svelte packages are not React Native targets.