### PR TITLE
[2.x] Declare Laravel Echo as an adapter dependency

### DIFF
--- a/packages/laravel-echo/tests/package-types.test.ts
+++ b/packages/laravel-echo/tests/package-types.test.ts
@@ -1,0 +1,92 @@
+/// <reference types="node" />
+
+import {
+    cpSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import ts from "typescript";
+import { expect, test } from "vitest";
+
+test.each(["react", "vue", "svelte"])(
+    "checks the published %s adapter without installing its development dependencies",
+    (adapter) => {
+        const directory = mkdtempSync(join(tmpdir(), "echo-types-"));
+        const packageDirectory = resolve(import.meta.dirname, "../..", adapter);
+        const installedPackage = join(
+            directory,
+            "node_modules/@laravel",
+            `echo-${adapter}`,
+        );
+
+        try {
+            mkdirSync(installedPackage, { recursive: true });
+            cpSync(
+                join(packageDirectory, "dist"),
+                join(installedPackage, "dist"),
+                { recursive: true },
+            );
+            cpSync(
+                join(packageDirectory, "package.json"),
+                join(installedPackage, "package.json"),
+            );
+            const { dependencies = {} } = JSON.parse(
+                readFileSync(join(installedPackage, "package.json"), "utf8"),
+            );
+
+            for (const dependency of [
+                ...Object.keys(dependencies),
+                adapter,
+                "pusher-js",
+                ...(adapter === "react" ? ["@types/react"] : []),
+            ]) {
+                const destination = join(directory, "node_modules", dependency);
+                mkdirSync(resolve(destination, ".."), { recursive: true });
+                symlinkSync(
+                    join(packageDirectory, "node_modules", dependency),
+                    destination,
+                    "junction",
+                );
+            }
+
+            const entry = join(directory, "index.ts");
+            writeFileSync(
+                entry,
+                `import type Echo from 'laravel-echo';
+            import { configureEcho, echo } from '@laravel/echo-${adapter}';
+            configureEcho({ broadcaster: 'reverb' });
+            const instance: Echo<'reverb'> = echo<'reverb'>();
+            instance.private('orders').listen('created', () => {});`,
+            );
+
+            const program = ts.createProgram([entry], {
+                noEmit: true,
+                strict: true,
+                skipLibCheck: false,
+                target: ts.ScriptTarget.ES2022,
+                module: ts.ModuleKind.ESNext,
+                moduleResolution: ts.ModuleResolutionKind.Bundler,
+                types: [],
+            });
+
+            expect(
+                ts
+                    .getPreEmitDiagnostics(program)
+                    .map((diagnostic) =>
+                        ts.flattenDiagnosticMessageText(
+                            diagnostic.messageText,
+                            "\n",
+                        ),
+                    ),
+            ).toEqual([]);
+        } finally {
+            rmSync(directory, { recursive: true, force: true });
+        }
+    },
+);

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -31,6 +31,9 @@
         "typecheck": "tsc --noEmit",
         "format": "prettier --write ."
     },
+    "dependencies": {
+        "laravel-echo": "workspace:^"
+    },
     "devDependencies": {
         "@eslint-react/eslint-plugin": "^5.18.6",
         "@microsoft/api-extractor": "^7.58.13",
@@ -44,7 +47,6 @@
         "eslint": "^10.8.1",
         "eslint-plugin-react-hooks": "^7.1.1",
         "jsdom": "^30.0.0",
-        "laravel-echo": "workspace:^",
         "prettier": "^3.5.3",
         "pusher-js": "^8.4.0",
         "react": "^19.1.0",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -31,6 +31,9 @@
         "typecheck": "tsc --noEmit",
         "format": "prettier --write ."
     },
+    "dependencies": {
+        "laravel-echo": "workspace:^"
+    },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.58.13",
         "@types/node": "^24.13.3",
@@ -38,7 +41,6 @@
         "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^10.8.1",
         "jsdom": "^30.0.0",
-        "laravel-echo": "workspace:^",
         "prettier": "^3.5.3",
         "pusher-js": "^8.4.0",
         "socket.io-client": "^4.8.1",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -31,6 +31,9 @@
         "typecheck": "tsc --noEmit",
         "format": "prettier --write ."
     },
+    "dependencies": {
+        "laravel-echo": "workspace:^"
+    },
     "devDependencies": {
         "@microsoft/api-extractor": "^7.58.13",
         "@types/node": "^24.13.3",
@@ -39,7 +42,6 @@
         "@vue/test-utils": "^2.4.11",
         "eslint": "^10.8.1",
         "jsdom": "^30.0.0",
-        "laravel-echo": "workspace:^",
         "prettier": "^3.5.3",
         "pusher-js": "^8.4.0",
         "socket.io-client": "^4.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,10 @@ importers:
         version: 5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3))
 
   packages/react:
+    dependencies:
+      laravel-echo:
+        specifier: workspace:^
+        version: link:../laravel-echo
     devDependencies:
       '@eslint-react/eslint-plugin':
         specifier: ^5.18.6
@@ -195,9 +199,6 @@ importers:
       jsdom:
         specifier: ^30.0.0
         version: 30.0.1
-      laravel-echo:
-        specifier: workspace:^
-        version: link:../laravel-echo
       prettier:
         specifier: ^3.5.3
         version: 3.9.6
@@ -227,6 +228,10 @@ importers:
         version: 5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3))
 
   packages/svelte:
+    dependencies:
+      laravel-echo:
+        specifier: workspace:^
+        version: link:../laravel-echo
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.13
@@ -246,9 +251,6 @@ importers:
       jsdom:
         specifier: ^30.0.0
         version: 30.0.1
-      laravel-echo:
-        specifier: workspace:^
-        version: link:../laravel-echo
       prettier:
         specifier: ^3.5.3
         version: 3.9.6
@@ -275,6 +277,10 @@ importers:
         version: 5.0.0(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.2(@types/node@24.13.3))
 
   packages/vue:
+    dependencies:
+      laravel-echo:
+        specifier: workspace:^
+        version: link:../laravel-echo
     devDependencies:
       '@microsoft/api-extractor':
         specifier: ^7.58.13
@@ -297,9 +303,6 @@ importers:
       jsdom:
         specifier: ^30.0.0
         version: 30.0.1
-      laravel-echo:
-        specifier: workspace:^
-        version: link:../laravel-echo
       prettier:
         specifier: ^3.5.3
         version: 3.9.6


### PR DESCRIPTION
A consumer can install an Echo adapter, its framework and Pusher, then fail TypeScript checking because `laravel-echo` is missing. The React, Vue and Svelte declarations import its types, but their manifests only list it as a development dependency.

Move the existing dependency into `dependencies` in all three adapters. The regression tests compile each built adapter outside the workspace, where development dependencies cannot satisfy the missing imports. They also check that the returned instance has the original Echo type.

All three cases fail before the manifest change. Tests, builds and type checks pass on Node 22 and 24, and the packed React adapter installs and compiles successfully. There are no runtime source changes.
